### PR TITLE
chore: add API errors to SDK

### DIFF
--- a/Coder Desktop/Coder Desktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Coder Desktop/Coder Desktop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "42dc2e0a0e0417a7f4f62b3e875c9559038beef7d2265073dd4fc81f2e11ee13",
+  "originHash" : "aa8dd97dc6e28dedc4a5c45c435467a247486474bf3c1caf5e67085d52325132",
   "pins" : [
     {
       "identity" : "alamofire",

--- a/Coder Desktop/Coder Desktop/Preview Content/PreviewClient.swift
+++ b/Coder Desktop/Coder Desktop/Preview Content/PreviewClient.swift
@@ -3,22 +3,26 @@ import SwiftUI
 struct PreviewClient: Client {
     init(url _: URL, token _: String? = nil) {}
 
-    func user(_: String) async throws -> User {
-        try await Task.sleep(for: .seconds(1))
-        return User(
-            id: UUID(),
-            username: "admin",
-            avatar_url: "",
-            name: "admin",
-            email: "admin@coder.com",
-            created_at: Date.now,
-            updated_at: Date.now,
-            last_seen_at: Date.now,
-            status: "active",
-            login_type: "none",
-            theme_preference: "dark",
-            organization_ids: [],
-            roles: []
-        )
+    func user(_: String) async throws(ClientError) -> User {
+        do {
+            try await Task.sleep(for: .seconds(1))
+            return User(
+                id: UUID(),
+                username: "admin",
+                avatar_url: "",
+                name: "admin",
+                email: "admin@coder.com",
+                created_at: Date.now,
+                updated_at: Date.now,
+                last_seen_at: Date.now,
+                status: "active",
+                login_type: "none",
+                theme_preference: "dark",
+                organization_ids: [],
+                roles: []
+            )
+        } catch {
+            throw ClientError.badResponse
+        }
     }
 }

--- a/Coder Desktop/Coder Desktop/Preview Content/PreviewClient.swift
+++ b/Coder Desktop/Coder Desktop/Preview Content/PreviewClient.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Alamofire
 
 struct PreviewClient: Client {
     init(url _: URL, token _: String? = nil) {}
@@ -22,7 +23,7 @@ struct PreviewClient: Client {
                 roles: []
             )
         } catch {
-            throw ClientError.badResponse
+            throw ClientError.reqError(AFError.explicitlyCancelled)
         }
     }
 }

--- a/Coder Desktop/Coder Desktop/SDK/Client.swift
+++ b/Coder Desktop/Coder Desktop/SDK/Client.swift
@@ -3,7 +3,7 @@ import Foundation
 
 protocol Client {
     init(url: URL, token: String?)
-    func user(_ ident: String) async throws -> User
+    func user(_ ident: String) async throws(ClientError) -> User
 }
 
 struct CoderClient: Client {
@@ -25,38 +25,122 @@ struct CoderClient: Client {
     func request<T: Encodable>(
         _ path: String,
         method: HTTPMethod,
-        body: T
-    ) async -> DataResponse<Data, AFError> {
+        body: T? = nil
+    ) async throws(ClientError) -> HTTPResponse {
         let url = self.url.appendingPathComponent(path)
-        let headers: HTTPHeaders = [Headers.sessionToken: token ?? ""]
-        return await AF.request(
+        let headers: HTTPHeaders? = token.map { [Headers.sessionToken: $0] }
+        let out = await AF.request(
             url,
             method: method,
             parameters: body,
-            encoder: JSONParameterEncoder.default,
             headers: headers
         ).serializingData().response
+        guard let response = out.response else {
+            throw ClientError.noResponse
+        }
+        switch out.result {
+        case .success(let data):
+            return HTTPResponse(resp: response, data: data, req: out.request)
+        case .failure:
+            throw ClientError.badResponse
+        }
     }
 
     func request(
         _ path: String,
         method: HTTPMethod
-    ) async -> DataResponse<Data, AFError> {
+    ) async throws(ClientError) -> HTTPResponse {
         let url = self.url.appendingPathComponent(path)
-        let headers: HTTPHeaders = [Headers.sessionToken: token ?? ""]
-        return await AF.request(
+        let headers: HTTPHeaders? = token.map { [Headers.sessionToken: $0] }
+        let out = await AF.request(
             url,
             method: method,
             headers: headers
         ).serializingData().response
+        guard let response = out.response else {
+            throw ClientError.noResponse
+        }
+        switch out.result {
+        case .success(let data):
+            return HTTPResponse(resp: response, data: data, req: out.request)
+        case .failure:
+            throw ClientError.badResponse
+        }
+    }
+
+    func responseAsError(_ resp: HTTPResponse) throws(ClientError) -> APIError {
+        do {
+            let body = try CoderClient.decoder.decode(Response.self, from: resp.data)
+            return APIError(
+                response: body,
+                statusCode: resp.resp.statusCode,
+                method: resp.req?.httpMethod,
+                url: resp.req?.url
+            )
+        } catch {
+            throw ClientError.badResponse
+        }
+    }
+
+    enum Headers {
+        static let sessionToken = "Coder-Session-Token"
+    }
+
+}
+
+struct HTTPResponse {
+    let resp: HTTPURLResponse
+    let data: Data
+    let req: URLRequest?
+}
+
+struct APIError: Decodable {
+    let response: Response
+    let statusCode: Int
+    let method: String?
+    let url: URL?
+
+    var description: String {
+        var components: [String] = []
+        if let method = method, let url = url {
+            components.append("\(method) \(url.absoluteString)")
+        }
+        components.append("Unexpected status code \(statusCode):\n\(response.message)")
+        if let detail = response.detail {
+            components.append("\tError: \(detail)")
+        }
+        if let validations = response.validations, !validations.isEmpty {
+            let validationMessages = validations.map { "\t\($0.field): \($0.detail)" }
+            components.append(contentsOf: validationMessages)
+        }
+        return components.joined(separator: "\n")
     }
 }
 
-enum ClientError: Error {
-    case unexpectedStatusCode
-    case badResponse
+struct Response: Decodable {
+    let message: String
+    let detail: String?
+    let validations: [ValidationError]?
 }
 
-enum Headers {
-    static let sessionToken = "Coder-Session-Token"
+struct ValidationError: Decodable {
+    let field: String
+    let detail: String
+}
+
+enum ClientError: Error {
+    case apiError(APIError)
+    case badResponse
+    case noResponse
+
+    var description: String {
+        switch self {
+        case .apiError(let error):
+            return error.description
+        case .badResponse:
+            return "Bad response"
+        case .noResponse:
+            return "No response"
+        }
+    }
 }

--- a/Coder Desktop/Coder Desktop/SDK/User.swift
+++ b/Coder Desktop/Coder Desktop/SDK/User.swift
@@ -4,13 +4,12 @@ extension CoderClient {
     func user(_ ident: String) async throws(ClientError) -> User {
         let res = try await request("/api/v2/users/\(ident)", method: .get)
         guard res.resp.statusCode == 200 else {
-            let error = try responseAsError(res)
-            throw ClientError.apiError(error)
+            throw responseAsError(res)
         }
         do {
             return try CoderClient.decoder.decode(User.self, from: res.data)
         } catch {
-            throw ClientError.badResponse
+            throw ClientError.unexpectedResponse(res.data[...1024])
         }
     }
 }

--- a/Coder Desktop/Coder Desktop/SDK/User.swift
+++ b/Coder Desktop/Coder Desktop/SDK/User.swift
@@ -1,15 +1,17 @@
 import Foundation
 
 extension CoderClient {
-    func user(_ ident: String) async throws -> User {
-        let resp = await request("/api/v2/users/\(ident)", method: .get)
-        guard let response = resp.response, response.statusCode == 200 else {
-            throw ClientError.unexpectedStatusCode
+    func user(_ ident: String) async throws(ClientError) -> User {
+        let res = try await request("/api/v2/users/\(ident)", method: .get)
+        guard res.resp.statusCode == 200 else {
+            let error = try responseAsError(res)
+            throw ClientError.apiError(error)
         }
-        guard let data = resp.data else {
+        do {
+            return try CoderClient.decoder.decode(User.self, from: res.data)
+        } catch {
             throw ClientError.badResponse
         }
-        return try CoderClient.decoder.decode(User.self, from: data)
     }
 }
 

--- a/Coder Desktop/Coder DesktopTests/AgentsTests.swift
+++ b/Coder Desktop/Coder DesktopTests/AgentsTests.swift
@@ -56,7 +56,7 @@ struct AgentsTests {
         vpn.state = .connected
         vpn.agents = createMockAgents(count: 7)
 
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 var toggle = try view.find(ViewType.Toggle.self)
                 #expect(try toggle.labelView().text().string() == "Show All")

--- a/Coder Desktop/Coder DesktopTests/Util.swift
+++ b/Coder Desktop/Coder DesktopTests/Util.swift
@@ -69,7 +69,7 @@ struct MockClient: Client {
 struct MockErrorClient: Client {
     init(url: URL, token: String?) {}
     func user(_ ident: String) async throws(ClientError) -> Coder_Desktop.User {
-        throw ClientError.badResponse
+        throw ClientError.reqError(.explicitlyCancelled)
     }
 }
 

--- a/Coder Desktop/Coder DesktopTests/Util.swift
+++ b/Coder Desktop/Coder DesktopTests/Util.swift
@@ -47,7 +47,7 @@ class MockSession: Session {
 struct MockClient: Client {
     init(url _: URL, token _: String? = nil) {}
 
-    func user(_: String) async throws -> Coder_Desktop.User {
+    func user(_: String) async throws(ClientError) -> Coder_Desktop.User {
         User(
             id: UUID(),
             username: "admin",
@@ -68,9 +68,9 @@ struct MockClient: Client {
 
 struct MockErrorClient: Client {
     init(url: URL, token: String?) {}
-    func user(_ ident: String) async throws -> Coder_Desktop.User {
+    func user(_ ident: String) async throws(ClientError) -> Coder_Desktop.User {
         throw ClientError.badResponse
     }
 }
 
-extension Inspection: @retroactive InspectionEmissary { }
+extension Inspection: @unchecked Sendable, @retroactive InspectionEmissary { }

--- a/Coder Desktop/Coder DesktopTests/VPNMenuTests.swift
+++ b/Coder Desktop/Coder DesktopTests/VPNMenuTests.swift
@@ -22,7 +22,7 @@ struct VPNMenuTests {
     func testVPNLoggedOut() async throws {
         session.hasSession = false
 
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 let toggle = try view.find(ViewType.Toggle.self)
                 #expect(toggle.isDisabled())
@@ -35,7 +35,7 @@ struct VPNMenuTests {
     @Test
     @MainActor
     func testStartStopCalled() async throws {
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 var toggle = try view.find(ViewType.Toggle.self)
                 #expect(try !toggle.isOn())
@@ -62,7 +62,7 @@ struct VPNMenuTests {
     func testVPNDisabledWhileConnecting() async throws {
         vpn.state = .disabled
 
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 var toggle = try view.find(ViewType.Toggle.self)
                 #expect(try !toggle.isOn())
@@ -83,7 +83,7 @@ struct VPNMenuTests {
     func testVPNDisabledWhileDisconnecting() async throws {
         vpn.state = .disabled
 
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 var toggle = try view.find(ViewType.Toggle.self)
                 #expect(try !toggle.isOn())
@@ -108,7 +108,7 @@ struct VPNMenuTests {
     @Test
     @MainActor
     func testOffWhenFailed() async throws {
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 let toggle = try view.find(ViewType.Toggle.self)
                 #expect(try !toggle.isOn())

--- a/Coder Desktop/Coder DesktopTests/VPNStateTests.swift
+++ b/Coder Desktop/Coder DesktopTests/VPNStateTests.swift
@@ -20,7 +20,7 @@ struct VPNStateTests {
     func testDisabledState() async throws {
         vpn.state = .disabled
 
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 #expect(throws: Never.self) {
                     try view.find(text: "Enable CoderVPN to see agents")
@@ -34,7 +34,7 @@ struct VPNStateTests {
     func testConnectingState() async throws {
         vpn.state = .connecting
 
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 let progressView = try view.find(ViewType.ProgressView.self)
                 #expect(try progressView.labelView().text().string() == "Starting CoderVPN...")
@@ -47,7 +47,7 @@ struct VPNStateTests {
     func testDisconnectingState() async throws {
         vpn.state = .disconnecting
 
-        try await ViewHosting.host(view) { _ in
+        try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 let progressView = try view.find(ViewType.ProgressView.self)
                 #expect(try progressView.labelView().text().string() == "Stopping CoderVPN...")
@@ -60,7 +60,7 @@ struct VPNStateTests {
     func testFailedState() async throws {
         vpn.state = .failed(.exampleError)
 
-        try await ViewHosting.host(view.environmentObject(vpn)) { _ in
+        try await ViewHosting.host(view.environmentObject(vpn)) {
             try await sut.inspection.inspect { view in
                 let text = try view.find(ViewType.Text.self)
                 #expect(try text.string() == VPNServiceError.exampleError.description)
@@ -73,7 +73,7 @@ struct VPNStateTests {
     func testDefaultState() async throws {
         vpn.state = .connected
 
-        try await ViewHosting.host(view.environmentObject(vpn)) { _ in
+        try await ViewHosting.host(view.environmentObject(vpn)) {
             try await sut.inspection.inspect { view in
                 #expect(throws: (any Error).self) {
                     _ = try view.find(ViewType.Text.self)


### PR DESCRIPTION
Cleanup PR to:
- Handle error responses from SDK, improve the error handling
- Replace the login flow errors with a popup, so we can actually display the full error
- Update ViewInspector and fix a deprecation warning in the tests
<img width="458" alt="image" src="https://github.com/user-attachments/assets/a1cb5828-d682-4c5d-a533-820ff8f20d2a" />