### PR TITLE
chore: upgrade Proto code to Swift 6

### DIFF
--- a/Coder Desktop/Coder Desktop.xcodeproj/project.pbxproj
+++ b/Coder Desktop/Coder Desktop.xcodeproj/project.pbxproj
@@ -660,7 +660,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.coder.Coder-Desktop";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -690,7 +690,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.coder.Coder-Desktop";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -835,7 +835,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.coder.Coder-Desktop.ProtoTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Coder Desktop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Coder Desktop";
 			};
 			name = Debug;
@@ -853,7 +853,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.coder.Coder-Desktop.ProtoTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Coder Desktop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Coder Desktop";
 			};
 			name = Release;

--- a/Coder Desktop/Coder Desktop.xcodeproj/xcshareddata/xcschemes/ProtoTests.xcscheme
+++ b/Coder Desktop/Coder Desktop.xcodeproj/xcshareddata/xcschemes/ProtoTests.xcscheme
@@ -54,6 +54,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "961678FB2CFF100D00B2B6DF"
+            BuildableName = "Coder Desktop.app"
+            BlueprintName = "Coder Desktop"
+            ReferencedContainer = "container:Coder Desktop.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Coder Desktop/Proto/Receiver.swift
+++ b/Coder Desktop/Proto/Receiver.swift
@@ -22,7 +22,7 @@ actor Receiver<RecvMsg: Message> {
             dispatch.read(offset: 0, length: 4, queue: queue) { done, data, error in
                 guard error == 0 else {
                     let errStrPtr = strerror(error)
-                    let errStr = String(validatingUTF8: errStrPtr!)!
+                    let errStr = String(validatingCString: errStrPtr!)!
                     continuation.resume(throwing: ReceiveError.readError(errStr))
                     return
                 }
@@ -42,7 +42,7 @@ actor Receiver<RecvMsg: Message> {
             dispatch.read(offset: 0, length: Int(length), queue: queue) { done, data, error in
                 guard error == 0 else {
                     let errStrPtr = strerror(error)
-                    let errStr = String(validatingUTF8: errStrPtr!)!
+                    let errStr = String(validatingCString: errStrPtr!)!
                     continuation.resume(throwing: ReceiveError.readError(errStr))
                     return
                 }


### PR DESCRIPTION
Upgrades Proto to Swift 6, mostly by telling the compiler explicitly that things are sendable, but in some cases by scoping down our closures so they only capture sendable objects.