### PR TITLE
chore: refactor speaker & handshaker into actors

### DIFF
--- a/Coder Desktop/Proto/Receiver.swift
+++ b/Coder Desktop/Proto/Receiver.swift
@@ -57,7 +57,7 @@ actor Receiver<RecvMsg: Message> {
 
     /// Starts reading protocol messages from the `DispatchIO` channel and returns them as an `AsyncStream` of messages.
     /// On read or decoding error, it logs and closes the stream.
-    func messages() throws -> AsyncStream<RecvMsg> {
+    func messages() throws(ReceiveError) -> AsyncStream<RecvMsg> {
         if running {
             throw ReceiveError.alreadyRunning
         }

--- a/Coder Desktop/Proto/Speaker.swift
+++ b/Coder Desktop/Proto/Speaker.swift
@@ -125,6 +125,7 @@ actor Speaker<SendMsg: RPCMessage & Message, RecvMsg: RPCMessage & Message> {
                 }
             } catch {
                 self.logger.error("failed to receive messages: \(error)")
+                throw error
             }
         }
     }

--- a/Coder Desktop/ProtoTests/SpeakerTests.swift
+++ b/Coder Desktop/ProtoTests/SpeakerTests.swift
@@ -40,8 +40,6 @@ struct SpeakerTests: Sendable {
     }
 
     @Test func handleSingleMessage() async throws {
-        await uut.start()
-
         var s = Vpn_ManagerMessage()
         s.start = Vpn_StartRequest()
         await #expect(throws: Never.self) {
@@ -54,12 +52,9 @@ struct SpeakerTests: Sendable {
         }
         #expect(msg.msg == .start(Vpn_StartRequest()))
         try await sender.close()
-        try await uut.wait()
     }
 
     @Test func handleRPC() async throws {
-        await uut.start()
-
         var s = Vpn_ManagerMessage()
         s.start = Vpn_StartRequest()
         s.rpc = Vpn_RPC()
@@ -89,12 +84,13 @@ struct SpeakerTests: Sendable {
             #expect(count == 1)
         }
         try await sender.close()
-        try await uut.wait()
     }
 
     @Test func sendRPCs() async throws {
-        await uut.start()
-
+        // Speaker must be reading from the receiver for `unaryRPC` to return
+        Task {
+            for try await _ in uut {}
+        }
         async let managerDone = Task {
             var count = 0
             for try await req in try await receiver.messages() {
@@ -118,6 +114,5 @@ struct SpeakerTests: Sendable {
         await uut.closeWrite()
         _ = await managerDone
         try await sender.close()
-        try await uut.wait()
     }
 }

--- a/Coder Desktop/ProtoTests/SpeakerTests.swift
+++ b/Coder Desktop/ProtoTests/SpeakerTests.swift
@@ -2,50 +2,11 @@
 import Foundation
 import Testing
 
-/// A concrete, test class for the abstract Speaker, which overrides the handlers to send things to
-/// continuations we set in the test.
-class TestTunnel: Speaker<Vpn_TunnelMessage, Vpn_ManagerMessage>, @unchecked Sendable {
-    private var msgHandler: CheckedContinuation<Vpn_ManagerMessage, Error>?
-    override func handleMessage(_ msg: Vpn_ManagerMessage) {
-        msgHandler?.resume(returning: msg)
-    }
-
-    /// Runs the given closure asynchronously and returns the next non-RPC message received.
-    func expectMessage(with closure:
-        @escaping @Sendable () async -> Void) async throws -> Vpn_ManagerMessage
-    {
-        return try await withCheckedThrowingContinuation { continuation in
-            msgHandler = continuation
-            Task {
-                await closure()
-            }
-        }
-    }
-
-    private var rpcHandler: CheckedContinuation<RPCRequest<Vpn_TunnelMessage, Vpn_ManagerMessage>, Error>?
-    override func handleRPC(_ req: RPCRequest<Vpn_TunnelMessage, Vpn_ManagerMessage>) {
-        rpcHandler?.resume(returning: req)
-    }
-
-    /// Runs the given closure asynchronously and return the next non-RPC message received
-    func expectRPC(with closure:
-        @escaping @Sendable () async -> Void) async throws ->
-        RPCRequest<Vpn_TunnelMessage, Vpn_ManagerMessage>
-    {
-        return try await withCheckedThrowingContinuation { continuation in
-            rpcHandler = continuation
-            Task {
-                await closure()
-            }
-        }
-    }
-}
-
 @Suite(.timeLimit(.minutes(1)))
 struct SpeakerTests: Sendable {
     let pipeMT = Pipe()
     let pipeTM = Pipe()
-    let uut: TestTunnel
+    let uut: Speaker<Vpn_TunnelMessage, Vpn_ManagerMessage>
     let sender: Sender<Vpn_ManagerMessage>
     let dispatch: DispatchIO
     let receiver: Receiver<Vpn_TunnelMessage>
@@ -53,7 +14,7 @@ struct SpeakerTests: Sendable {
 
     init() {
         let queue = DispatchQueue.global(qos: .utility)
-        uut = TestTunnel(
+        uut = Speaker(
             writeFD: pipeTM.fileHandleForWriting,
             readFD: pipeMT.fileHandleForReading
         )
@@ -79,39 +40,45 @@ struct SpeakerTests: Sendable {
     }
 
     @Test func handleSingleMessage() async throws {
-        async let readDone: () = try uut.readLoop()
+        await uut.start()
 
-        let got = try await uut.expectMessage {
-            var s = Vpn_ManagerMessage()
-            s.start = Vpn_StartRequest()
-            await #expect(throws: Never.self) {
-                try await sender.send(s)
-            }
+        var s = Vpn_ManagerMessage()
+        s.start = Vpn_StartRequest()
+        await #expect(throws: Never.self) {
+            try await sender.send(s)
         }
-        #expect(got.msg == .start(Vpn_StartRequest()))
+        let got = try #require(await uut.next())
+        guard case let .message(msg) = got else {
+            Issue.record("Received unexpected message from speaker")
+            return
+        }
+        #expect(msg.msg == .start(Vpn_StartRequest()))
         try await sender.close()
-        try await readDone
+        try await uut.wait()
     }
 
     @Test func handleRPC() async throws {
-        async let readDone: () = try uut.readLoop()
+        await uut.start()
 
-        let got = try await uut.expectRPC {
-            var s = Vpn_ManagerMessage()
-            s.start = Vpn_StartRequest()
-            s.rpc = Vpn_RPC()
-            s.rpc.msgID = 33
-            await #expect(throws: Never.self) {
-                try await sender.send(s)
-            }
+        var s = Vpn_ManagerMessage()
+        s.start = Vpn_StartRequest()
+        s.rpc = Vpn_RPC()
+        s.rpc.msgID = 33
+        await #expect(throws: Never.self) {
+            try await sender.send(s)
         }
-        #expect(got.msg.msg == .start(Vpn_StartRequest()))
-        #expect(got.msg.rpc.msgID == 33)
+        let got = try #require(await uut.next())
+        guard case let .RPC(req) = got else {
+            Issue.record("Received unexpected message from speaker")
+            return
+        }
+        #expect(req.msg.msg == .start(Vpn_StartRequest()))
+        #expect(req.msg.rpc.msgID == 33)
         var reply = Vpn_TunnelMessage()
         reply.start = Vpn_StartResponse()
         reply.rpc.responseTo = 33
-        try await got.sendReply(reply)
-        uut.closeWrite()
+        try await req.sendReply(reply)
+        await uut.closeWrite()
 
         var count = 0
         await #expect(throws: Never.self) {
@@ -122,11 +89,11 @@ struct SpeakerTests: Sendable {
             #expect(count == 1)
         }
         try await sender.close()
-        try await readDone
+        try await uut.wait()
     }
 
     @Test func sendRPCs() async throws {
-        async let readDone: () = try uut.readLoop()
+        await uut.start()
 
         async let managerDone = Task {
             var count = 0
@@ -148,9 +115,9 @@ struct SpeakerTests: Sendable {
             let got = try await uut.unaryRPC(req)
             #expect(got.networkSettings.errorMessage == "test \(i)")
         }
-        uut.closeWrite()
+        await uut.closeWrite()
         _ = await managerDone
         try await sender.close()
-        try await readDone
+        try await uut.wait()
     }
 }

--- a/Coder Desktop/ProtoTests/SpeakerTests.swift
+++ b/Coder Desktop/ProtoTests/SpeakerTests.swift
@@ -88,7 +88,7 @@ struct SpeakerTests: Sendable {
 
     @Test func sendRPCs() async throws {
         // Speaker must be reading from the receiver for `unaryRPC` to return
-        Task {
+        let readDone = Task {
             for try await _ in uut {}
         }
         async let managerDone = Task {
@@ -114,5 +114,6 @@ struct SpeakerTests: Sendable {
         await uut.closeWrite()
         _ = await managerDone
         try await sender.close()
+        try await readDone.value
     }
 }


### PR DESCRIPTION
Instead of relying on class inheritance, the new Speaker can composed into whatever would like to speak the CoderVPN protocol, and messages can be handled by iterating over the speaker itself e.g:

```swift
enum IncomingMessage {
    case message(RecvMsg)
    case RPC(RPCRequest<SendMsg, RecvMsg>)
}
```

```swift
for try await msg in speaker {
    switch msg {
    case let .message(msg):
        // Handle message that doesn't require a response
    case let .RPC(req):
        // Handle incoming RPC
    }
}
```