### PR TITLE
fix: set pipefail during make test

### DIFF
--- a/Coder Desktop/Coder DesktopTests/Util.swift
+++ b/Coder Desktop/Coder DesktopTests/Util.swift
@@ -1,5 +1,6 @@
 @testable import Coder_Desktop
 import Combine
+import NetworkExtension
 import SwiftUI
 import ViewInspector
 
@@ -20,6 +21,8 @@ class MockVPNService: VPNService, ObservableObject {
         state = .disconnecting
         await onStop?()
     }
+
+    func configureTunnelProviderProtocol(proto _: NETunnelProviderProtocol?) {}
 }
 
 class MockSession: Session {
@@ -40,6 +43,10 @@ class MockSession: Session {
         hasSession = false
         sessionToken = nil
         baseAccessURL = nil
+    }
+
+    func tunnelProviderProtocol() -> NETunnelProviderProtocol? {
+        return nil
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ fmt:
 		$(FMTFLAGS) .
 
 test:
-	xcodebuild test \
+	set -o pipefail && xcodebuild test \
 		-project $(PROJECT) \
 		-scheme $(SCHEME) \
 		-testPlan $(SCHEME) \


### PR DESCRIPTION
Tests that didn't compile got merged to main because `pipefail` wasn't set when piping the output of `xcodebuild` into `xcpretty`.