### PR TITLE
chore: gracefully shutdown app

### DIFF
--- a/Coder Desktop/Coder Desktop/Coder_DesktopApp.swift
+++ b/Coder Desktop/Coder Desktop/Coder_DesktopApp.swift
@@ -37,6 +37,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+        Task {
+            await vpn.stop()
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {
         false
     }

--- a/Coder Desktop/Coder Desktop/Preview Content/PreviewVPN.swift
+++ b/Coder Desktop/Coder Desktop/Preview Content/PreviewVPN.swift
@@ -47,7 +47,7 @@ final class PreviewVPN: Coder_Desktop.VPNService {
     var stopTask: Task<Void, Never>?
     func stop() async {
         await startTask?.value
-        guard state == .connected else { return}
+        guard state == .connected else { return }
         if await stopTask?.value != nil {
             return
         }

--- a/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
@@ -59,10 +59,7 @@ struct VPNMenu<VPN: VPNService, S: Session>: View {
                 }.buttonStyle(.plain)
                 TrayDivider()
                 Button {
-                    Task {
-                        await vpn.stop()
-                        NSApp.terminate(nil)
-                    }
+                    NSApp.terminate(nil)
                 } label: {
                     ButtonRowView {
                         Text("Quit")


### PR DESCRIPTION
When the app is quit (terminated), in any way, an active VPN connection should first be shutdown by sending the stop response over the tunnel. Previously we were only catching when the app was closed via the quit button we supply, but we can actually catch any non-force-quit terminations using the `AppDelegate`.

Additionally:
- Quitting the app while the VPN is stopping should wait for the existing stop operation to finish
- Quitting the app while the VPN is starting should wait for the start operation to finish, and then start and wait for a stop operation.
 