### PR TITLE
fix: hold delegate reference to keep it from being deallocated

### DIFF
--- a/Coder Desktop/Coder Desktop/SystemExtension.swift
+++ b/Coder Desktop/Coder Desktop/SystemExtension.swift
@@ -29,6 +29,10 @@ protocol SystemExtensionAsyncRecorder: Sendable {
 extension CoderVPNService: SystemExtensionAsyncRecorder {
     func recordSystemExtensionState(_ state: SystemExtensionState) async {
         sysExtnState = state
+        if state == .installed {
+            // system extension was successfully installed, so we don't need the delegate any more
+            systemExtnDelegate = nil
+        }
     }
 
     var extensionBundle: Bundle {
@@ -71,6 +75,7 @@ extension CoderVPNService: SystemExtensionAsyncRecorder {
             queue: .main
         )
         let delegate = SystemExtensionDelegate(asyncDelegate: self)
+        systemExtnDelegate = delegate
         request.delegate = delegate
         OSSystemExtensionManager.shared.submitRequest(request)
         logger.info("submitted SystemExtension request with bundleID: \(bundleID)")
@@ -87,6 +92,7 @@ class SystemExtensionDelegate<AsyncDelegate: SystemExtensionAsyncRecorder>:
 
     init(asyncDelegate: AsyncDelegate) {
         self.asyncDelegate = asyncDelegate
+        super.init()
         logger.info("SystemExtensionDelegate initialized")
     }
 

--- a/Coder Desktop/Coder Desktop/VPNService.swift
+++ b/Coder Desktop/Coder Desktop/VPNService.swift
@@ -58,6 +58,11 @@ final class CoderVPNService: NSObject, VPNService {
 
     @Published var agents: [Agent] = []
 
+    // systemExtnDelegate holds a reference to the SystemExtensionDelegate so that it doesn't get
+    // garbage collected while the OSSystemExtensionRequest is in flight, since the OS framework
+    // only stores a weak reference to the delegate.
+    var systemExtnDelegate: SystemExtensionDelegate<CoderVPNService>?
+
     override init() {
         super.init()
         installSystemExtension()


### PR DESCRIPTION
The problem we were having before was being caused by the system extension delegate being deallocated before the request responses came back.

I didn't initially realize this, but the [OSSystemRequest.delegate](https://developer.apple.com/documentation/systemextensions/ossystemextensionrequest/delegate) is a weak reference (you have to click down to the individual field view in the docs to learn this).

So, we keep a strong reference from the VPNService around while we are waiting for the extension to install.