### PR TITLE
chore: support operating the VPN without the app

### DIFF
--- a/Coder Desktop/Coder Desktop/Coder_DesktopApp.swift
+++ b/Coder Desktop/Coder Desktop/Coder_DesktopApp.swift
@@ -47,7 +47,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MUST eventually call `NSApp.reply(toApplicationShouldTerminate: true)`
+    // This function MUST eventually call `NSApp.reply(toApplicationShouldTerminate: true)`
     // or return `.terminateNow`
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
         if !settings.stopVPNOnQuit { return .terminateNow }

--- a/Coder Desktop/Coder Desktop/Coder_DesktopApp.swift
+++ b/Coder Desktop/Coder Desktop/Coder_DesktopApp.swift
@@ -47,9 +47,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MUST eventually call `NSApp.reply(toApplicationShouldTerminate: true)`
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
         Task {
-            await vpn.quit()
+            await vpn.stop()
+            NSApp.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater
     }

--- a/Coder Desktop/Coder Desktop/Coder_DesktopApp.swift
+++ b/Coder Desktop/Coder Desktop/Coder_DesktopApp.swift
@@ -48,7 +48,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     // MUST eventually call `NSApp.reply(toApplicationShouldTerminate: true)`
+    // or return `.terminateNow`
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+        if !settings.stopVPNOnQuit { return .terminateNow }
         Task {
             await vpn.stop()
             NSApp.reply(toApplicationShouldTerminate: true)

--- a/Coder Desktop/Coder Desktop/NetworkExtension.swift
+++ b/Coder Desktop/Coder Desktop/NetworkExtension.swift
@@ -24,6 +24,15 @@ enum NetworkExtensionState: Equatable {
 /// An actor that handles configuring, enabling, and disabling the VPN tunnel via the
 /// NetworkExtension APIs.
 extension CoderVPNService {
+    func hasNetworkExtensionConfig() async -> Bool {
+        do {
+            _ = try await getTunnelManager()
+            return true
+        } catch {
+            return false
+        }
+    }
+
     func configureNetworkExtension(proto: NETunnelProviderProtocol) async {
         // removing the old tunnels, rather than reconfiguring ensures that configuration changes
         // are picked up.
@@ -61,7 +70,7 @@ extension CoderVPNService {
         }
     }
 
-    func enableNetworkExtension() async {
+    func startTunnel() async {
         do {
             let tm = try await getTunnelManager()
             try tm.connection.startVPNTunnel()
@@ -74,7 +83,7 @@ extension CoderVPNService {
         neState = .enabled
     }
 
-    func disableNetworkExtension() async {
+    func stopTunnel() async {
         do {
             let tm = try await getTunnelManager()
             tm.connection.stopVPNTunnel()
@@ -88,7 +97,7 @@ extension CoderVPNService {
     }
 
     @discardableResult
-    func getTunnelManager() async throws(VPNServiceError) -> NETunnelProviderManager {
+    private func getTunnelManager() async throws(VPNServiceError) -> NETunnelProviderManager {
         var tunnels: [NETunnelProviderManager] = []
         do {
             tunnels = try await NETunnelProviderManager.loadAllFromPreferences()

--- a/Coder Desktop/Coder Desktop/State.swift
+++ b/Coder Desktop/Coder Desktop/State.swift
@@ -104,6 +104,8 @@ class Settings: ObservableObject {
         }
     }
 
+    @AppStorage(Keys.stopVPNOnQuit) var stopVPNOnQuit = true
+
     init(store: UserDefaults = .standard) {
         self.store = store
         _literalHeaders = Published(
@@ -116,6 +118,7 @@ class Settings: ObservableObject {
     enum Keys {
         static let useLiteralHeaders = "UseLiteralHeaders"
         static let literalHeaders = "LiteralHeaders"
+        static let stopVPNOnQuit = "StopVPNOnQuit"
     }
 }
 

--- a/Coder Desktop/Coder Desktop/SystemExtension.swift
+++ b/Coder Desktop/Coder Desktop/SystemExtension.swift
@@ -29,7 +29,16 @@ protocol SystemExtensionAsyncRecorder: Sendable {
 extension CoderVPNService: SystemExtensionAsyncRecorder {
     func recordSystemExtensionState(_ state: SystemExtensionState) async {
         sysExtnState = state
+        if state == .uninstalled {
+            installSystemExtension()
+        }
         if state == .installed {
+            do {
+                try await getTunnelManager()
+                neState = .disabled
+            } catch {
+                neState = .unconfigured
+            }
             // system extension was successfully installed, so we don't need the delegate any more
             systemExtnDelegate = nil
         }
@@ -64,7 +73,21 @@ extension CoderVPNService: SystemExtensionAsyncRecorder {
         return extensionBundle
     }
 
-    func installSystemExtension() {
+    func checkSystemExtensionStatus() {
+        logger.info("checking SystemExtension status")
+        guard let bundleID = extensionBundle.bundleIdentifier else {
+            logger.error("Bundle has no identifier")
+            return
+        }
+        let request = OSSystemExtensionRequest.propertiesRequest(forExtensionWithIdentifier: bundleID, queue: .main)
+        let delegate = SystemExtensionDelegate(asyncDelegate: self)
+        request.delegate = delegate
+        systemExtnDelegate = delegate
+        OSSystemExtensionManager.shared.submitRequest(request)
+        logger.info("submitted SystemExtension properties request with bundleID: \(bundleID)")
+    }
+
+    private func installSystemExtension() {
         logger.info("activating SystemExtension")
         guard let bundleID = extensionBundle.bundleIdentifier else {
             logger.error("Bundle has no identifier")
@@ -74,11 +97,9 @@ extension CoderVPNService: SystemExtensionAsyncRecorder {
             forExtensionWithIdentifier: bundleID,
             queue: .main
         )
-        let delegate = SystemExtensionDelegate(asyncDelegate: self)
-        systemExtnDelegate = delegate
-        request.delegate = delegate
+        request.delegate = systemExtnDelegate
         OSSystemExtensionManager.shared.submitRequest(request)
-        logger.info("submitted SystemExtension request with bundleID: \(bundleID)")
+        logger.info("submitted SystemExtension activate request with bundleID: \(bundleID)")
     }
 }
 
@@ -88,6 +109,8 @@ class SystemExtensionDelegate<AsyncDelegate: SystemExtensionAsyncRecorder>:
     NSObject, OSSystemExtensionRequestDelegate
 {
     private var logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "vpn-installer")
+    // TODO: Refactor this to use a continuation, so the result of a request can be
+    // 'await'd for the determined state
     private var asyncDelegate: AsyncDelegate
 
     init(asyncDelegate: AsyncDelegate) {
@@ -137,5 +160,39 @@ class SystemExtensionDelegate<AsyncDelegate: SystemExtensionAsyncRecorder>:
         // swiftlint:disable:next line_length
         logger.info("Replacing \(request.identifier) v\(existing.bundleShortVersion) with v\(`extension`.bundleShortVersion)")
         return .replace
+    }
+
+    public func request(
+        _: OSSystemExtensionRequest,
+        foundProperties properties: [OSSystemExtensionProperties]
+    ) {
+        // In debug builds we always replace the SE to test
+        // changes made without bumping the version
+       #if DEBUG
+           Task { [asyncDelegate] in
+               await asyncDelegate.recordSystemExtensionState(.uninstalled)
+           }
+           return
+       #else
+            let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+            let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+
+            let versionMatches = properties.contains { sysex in
+                sysex.isEnabled
+                    && sysex.bundleVersion == version
+                    && sysex.bundleShortVersion == shortVersion
+            }
+            if versionMatches {
+                Task { [asyncDelegate] in
+                    await asyncDelegate.recordSystemExtensionState(.installed)
+                }
+                return
+            }
+
+            // Either uninstalled or needs replacing
+            Task { [asyncDelegate] in
+                await asyncDelegate.recordSystemExtensionState(.uninstalled)
+            }
+       #endif
     }
 }

--- a/Coder Desktop/Coder Desktop/SystemExtension.swift
+++ b/Coder Desktop/Coder Desktop/SystemExtension.swift
@@ -73,7 +73,7 @@ extension CoderVPNService: SystemExtensionAsyncRecorder {
         return extensionBundle
     }
 
-    func checkSystemExtensionStatus() {
+    func attemptSystemExtensionInstall() {
         logger.info("checking SystemExtension status")
         guard let bundleID = extensionBundle.bundleIdentifier else {
             logger.error("Bundle has no identifier")

--- a/Coder Desktop/Coder Desktop/SystemExtension.swift
+++ b/Coder Desktop/Coder Desktop/SystemExtension.swift
@@ -168,12 +168,12 @@ class SystemExtensionDelegate<AsyncDelegate: SystemExtensionAsyncRecorder>:
     ) {
         // In debug builds we always replace the SE to test
         // changes made without bumping the version
-       #if DEBUG
-           Task { [asyncDelegate] in
-               await asyncDelegate.recordSystemExtensionState(.uninstalled)
-           }
-           return
-       #else
+        #if DEBUG
+            Task { [asyncDelegate] in
+                await asyncDelegate.recordSystemExtensionState(.uninstalled)
+            }
+            return
+        #else
             let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
             let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
 
@@ -193,6 +193,6 @@ class SystemExtensionDelegate<AsyncDelegate: SystemExtensionAsyncRecorder>:
             Task { [asyncDelegate] in
                 await asyncDelegate.recordSystemExtensionState(.uninstalled)
             }
-       #endif
+        #endif
     }
 }

--- a/Coder Desktop/Coder Desktop/VPNService.swift
+++ b/Coder Desktop/Coder Desktop/VPNService.swift
@@ -73,6 +73,7 @@ final class CoderVPNService: NSObject, VPNService {
                 .unconfigured
             }
         }
+        xpc.connect()
         xpc.getPeerState()
         NotificationCenter.default.addObserver(
             self,
@@ -100,7 +101,7 @@ final class CoderVPNService: NSObject, VPNService {
         }
 
         await startTunnel()
-        // this ping is somewhat load bearing since it causes xpc to init
+        xpc.connect()
         xpc.ping()
         logger.debug("network extension enabled")
     }

--- a/Coder Desktop/Coder Desktop/VPNService.swift
+++ b/Coder Desktop/Coder Desktop/VPNService.swift
@@ -65,7 +65,7 @@ final class CoderVPNService: NSObject, VPNService {
 
     override init() {
         super.init()
-        checkSystemExtensionStatus()
+        attemptSystemExtensionInstall()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(vpnDidUpdate(_:)),

--- a/Coder Desktop/Coder Desktop/VPNService.swift
+++ b/Coder Desktop/Coder Desktop/VPNService.swift
@@ -220,7 +220,7 @@ extension CoderVPNService {
         case .connected:
             // If we moved from disabled to connected, then the NE was already
             // running, and we need to request the current peer state
-            if self.tunnelState == .disabled {
+            if tunnelState == .disabled {
                 xpc.getPeerState()
             }
             tunnelState = .connected

--- a/Coder Desktop/Coder Desktop/Views/Settings/GeneralTab.swift
+++ b/Coder Desktop/Coder Desktop/Views/Settings/GeneralTab.swift
@@ -2,10 +2,16 @@ import LaunchAtLogin
 import SwiftUI
 
 struct GeneralTab: View {
+    @EnvironmentObject var settings: Settings
     var body: some View {
         Form {
             Section {
                 LaunchAtLogin.Toggle("Launch at Login")
+            }
+            Section {
+                Toggle(isOn: $settings.stopVPNOnQuit) {
+                    Text("Stop VPN on Quit")
+                }
             }
         }.formStyle(.grouped)
     }

--- a/Coder Desktop/Coder Desktop/XPCInterface.swift
+++ b/Coder Desktop/Coder Desktop/XPCInterface.swift
@@ -6,7 +6,7 @@ import VPNLib
 @objc final class VPNXPCInterface: NSObject, VPNXPCClientCallbackProtocol, @unchecked Sendable {
     private var svc: CoderVPNService
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "VPNXPCInterface")
-    private var xpc: VPNXPCProtocol? = nil
+    private var xpc: VPNXPCProtocol?
 
     init(vpn: CoderVPNService) {
         svc = vpn
@@ -14,6 +14,9 @@ import VPNLib
     }
 
     func connect() {
+        guard xpc == nil else {
+            return
+        }
         let networkExtDict = Bundle.main.object(forInfoDictionaryKey: "NetworkExtension") as? [String: Any]
         let machServiceName = networkExtDict?["NEMachServiceName"] as? String
         let xpcConn = NSXPCConnection(machServiceName: machServiceName!)

--- a/Coder Desktop/Coder Desktop/XPCInterface.swift
+++ b/Coder Desktop/Coder Desktop/XPCInterface.swift
@@ -45,6 +45,14 @@ import VPNLib
         }
     }
 
+    func getPeerState() {
+        xpc.getPeerState { data in
+            Task { @MainActor in
+                self.svc.onExtensionPeerState(data)
+            }
+        }
+    }
+
     func onPeerUpdate(_ data: Data) {
         Task { @MainActor in
             svc.onExtensionPeerUpdate(data)

--- a/Coder Desktop/Coder Desktop/XPCInterface.swift
+++ b/Coder Desktop/Coder Desktop/XPCInterface.swift
@@ -6,11 +6,14 @@ import VPNLib
 @objc final class VPNXPCInterface: NSObject, VPNXPCClientCallbackProtocol, @unchecked Sendable {
     private var svc: CoderVPNService
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "VPNXPCInterface")
-    private let xpc: VPNXPCProtocol
+    private var xpc: VPNXPCProtocol? = nil
 
     init(vpn: CoderVPNService) {
         svc = vpn
+        super.init()
+    }
 
+    func connect() {
         let networkExtDict = Bundle.main.object(forInfoDictionaryKey: "NetworkExtension") as? [String: Any]
         let machServiceName = networkExtDict?["NEMachServiceName"] as? String
         let xpcConn = NSXPCConnection(machServiceName: machServiceName!)
@@ -21,24 +24,24 @@ import VPNLib
         }
         xpc = proxy
 
-        super.init()
-
         xpcConn.exportedObject = self
         xpcConn.invalidationHandler = { [logger] in
             Task { @MainActor in
                 logger.error("XPC connection invalidated.")
+                self.xpc = nil
             }
         }
         xpcConn.interruptionHandler = { [logger] in
             Task { @MainActor in
                 logger.error("XPC connection interrupted.")
+                self.xpc = nil
             }
         }
         xpcConn.resume()
     }
 
     func ping() {
-        xpc.ping {
+        xpc?.ping {
             Task { @MainActor in
                 self.logger.info("Connected to NE over XPC")
             }
@@ -46,7 +49,7 @@ import VPNLib
     }
 
     func getPeerState() {
-        xpc.getPeerState { data in
+        xpc?.getPeerState { data in
             Task { @MainActor in
                 self.svc.onExtensionPeerState(data)
             }

--- a/Coder Desktop/VPN/Manager.swift
+++ b/Coder Desktop/VPN/Manager.swift
@@ -194,7 +194,7 @@ actor Manager {
 
     // Retrieves the current state of all peers,
     // as required when starting the app whilst the network extension is already running
-    func getPeerInfo() async throws(ManagerError) -> Vpn_PeerUpdate {
+    func getPeerState() async throws(ManagerError) -> Vpn_PeerUpdate {
         logger.info("sending peer state request")
         let resp: Vpn_TunnelMessage
         do {

--- a/Coder Desktop/VPN/XPCInterface.swift
+++ b/Coder Desktop/VPN/XPCInterface.swift
@@ -20,9 +20,12 @@ import VPNLib
         }
     }
 
-    func getPeerInfo(with reply: @escaping () -> Void) {
-        // TODO: Retrieve from Manager
-        reply()
+    func getPeerState(with reply: @escaping (Data?) -> Void) {
+        let reply = CallbackWrapper(reply)
+        Task {
+            let data = try? await manager?.getPeerState().serializedData()
+            reply(data)
+        }
     }
 
     func ping(with reply: @escaping () -> Void) {

--- a/Coder Desktop/VPNLib/XPC.swift
+++ b/Coder Desktop/VPNLib/XPC.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @preconcurrency
 @objc public protocol VPNXPCProtocol {
-    func getPeerInfo(with reply: @escaping () -> Void)
+    func getPeerState(with reply: @escaping (Data?) -> Void)
     func ping(with reply: @escaping () -> Void)
 }
 


### PR DESCRIPTION
Currently, CoderVPN disables it's system-level configuration when it's turned off. This means it can't be started and stopped from System Preferences. Since the network extension works fine without the app, we can remove this restriction.

However, it then becomes necessary to retrieve the state of the peers (agents) when starting the app whilst the VPN is running. We already have support for this on the dylib side, so this PR wires that functionality up over XPC.

Demo (I launch the app once the VPN reports itself as connected):

https://github.com/user-attachments/assets/53798b63-8b4e-4870-be99-ebafda173bca

This behaviour is only present in a Release build of the app. In a Debug build, launching the app will trigger a replacement of the network extension installed on the system, but not before disconnecting the VPN.
