### PR TITLE
fix(Makefile): remove suffix after patch number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: make release
 
       - name: Upload Release Assets
-        run: gh release upload "$RELEASE_TAG" "$out"
+        run: gh release upload "$RELEASE_TAG" "$out"/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ XCPROJECT := Coder\ Desktop/Coder\ Desktop.xcodeproj
 SCHEME := Coder\ Desktop
 SWIFT_VERSION := 6.0
 
-MARKETING_VERSION=$(shell git describe --tags --abbrev=0 | sed 's/^v//')
+MARKETING_VERSION=$(shell git describe --tags --abbrev=0 | sed 's/^v//' | sed 's/-.*$//')
 CURRENT_PROJECT_VERSION=$(shell git describe --tags)
 
 # Define the keychain file name first


### PR DESCRIPTION
Fixed release asset upload and version parsing

Using a glob pattern, the release workflow now correctly uploads all assets from the output directory. Version parsing in the Makefile has been updated to handle pre-release tags by removing trailing pre-release identifiers.

Change-Id: I15b816393880406c9ac6a7cbbd2b3344c338894c
Signed-off-by: Thomas Kosiewski <tk@coder.com>