### PR TITLE
fix(Makefile): add version validation checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
-
-      - run: git fetch --tags
 
       - name: Switch XCode Version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
@@ -45,10 +44,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
-
-      - run: git fetch --tags
 
       - name: Switch XCode Version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
@@ -69,10 +67,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
-
-      - run: git fetch --tags
 
       - name: Setup Nix
         uses: ./.github/actions/nix-devshell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
-
-      - run: git fetch --tags
 
       - name: Switch XCode Version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,15 @@ XCPROJECT := Coder\ Desktop/Coder\ Desktop.xcodeproj
 SCHEME := Coder\ Desktop
 SWIFT_VERSION := 6.0
 
-MARKETING_VERSION=$(shell git describe --tags --abbrev=0 | sed 's/^v//' | sed 's/-.*$//')
 CURRENT_PROJECT_VERSION=$(shell git describe --tags)
+ifeq ($(strip $(CURRENT_PROJECT_VERSION)),)
+    $(error CURRENT_PROJECT_VERSION cannot be empty)
+endif
+
+MARKETING_VERSION=$(shell git describe --tags --abbrev=0 | sed 's/^v//' | sed 's/-.*$$//')
+ifeq ($(strip $(MARKETING_VERSION)),)
+    $(error MARKETING_VERSION cannot be empty)
+endif
 
 # Define the keychain file name first
 KEYCHAIN_FILE := app-signing.keychain-db


### PR DESCRIPTION
Adds validation for version variables in Makefile

Ensures CURRENT_PROJECT_VERSION and MARKETING_VERSION are not empty when building the project, failing the build process with an error message if either variable cannot be determined from git tags.

Change-Id: I83265a11182df6d28f2ef3a5f5454adba27c95ea
Signed-off-by: Thomas Kosiewski <tk@coder.com>