### PR TITLE
chore: switch to nix-quick-install-action

### DIFF
--- a/.github/actions/nix-devshell/action.yaml
+++ b/.github/actions/nix-devshell/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Nix
-      uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d # v16
+      uses: nixbuild/nix-quick-install-action@25aff27c252e0c8cdda3264805f7b6bcd92c8718 # v29
 
     - name: Enter devshell
       uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1


### PR DESCRIPTION
Updates Nix installer action to nixbuild/nix-quick-install-action

Change-Id: I749e59d17cad8341c4c1e57c402573c14642152d
Signed-off-by: Thomas Kosiewski <tk@coder.com>