### PR TITLE
chore: handle waking from device sleep

### DIFF
--- a/Coder Desktop/Coder Desktop/VPNMenuState.swift
+++ b/Coder Desktop/Coder Desktop/VPNMenuState.swift
@@ -105,7 +105,7 @@ struct VPNMenuState {
     mutating func upsertWorkspace(_ workspace: Vpn_Workspace) {
         guard let wsID = UUID(uuidData: workspace.id) else { return }
         // Workspace names are unique & case-insensitive, and we want to show offline workspaces
-        // with a valid hostname (lowercase). 
+        // with a valid hostname (lowercase).
         workspaces[wsID] = Workspace(id: wsID, name: workspace.name.lowercased(), agents: [])
         // Check if we can associate any invalid agents with this workspace
         invalidAgents.filter { agent in

--- a/Coder Desktop/Coder Desktop/VPNMenuState.swift
+++ b/Coder Desktop/Coder Desktop/VPNMenuState.swift
@@ -104,7 +104,9 @@ struct VPNMenuState {
 
     mutating func upsertWorkspace(_ workspace: Vpn_Workspace) {
         guard let wsID = UUID(uuidData: workspace.id) else { return }
-        workspaces[wsID] = Workspace(id: wsID, name: workspace.name, agents: [])
+        // Workspace names are unique & case-insensitive, and we want to show offline workspaces
+        // with a valid hostname (lowercase). 
+        workspaces[wsID] = Workspace(id: wsID, name: workspace.name.lowercased(), agents: [])
         // Check if we can associate any invalid agents with this workspace
         invalidAgents.filter { agent in
             agent.workspaceID == workspace.id

--- a/Coder Desktop/Coder Desktop/VPNService.swift
+++ b/Coder Desktop/Coder Desktop/VPNService.swift
@@ -90,6 +90,7 @@ final class CoderVPNService: NSObject, VPNService {
             return
         }
 
+        menuState.clear()
         await startTunnel()
         logger.debug("network extension enabled")
     }

--- a/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
@@ -86,7 +86,7 @@ struct VPNMenu<VPN: VPNService>: View {
     }
 
     private var vpnDisabled: Bool {
-        !session.hasSession ||
+        !state.hasSession ||
             vpn.state == .connecting ||
             vpn.state == .disconnecting ||
             vpn.state == .failed(.systemExtensionError(.needsUserApproval))

--- a/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
@@ -5,13 +5,6 @@ struct VPNMenu<VPN: VPNService>: View {
     @EnvironmentObject var state: AppState
     @Environment(\.openSettings) private var openSettings
 
-    // There appears to be a race between the VPN service reporting itself as disconnected,
-    // and the system extension process exiting. When the VPN is toggled off and on quickly,
-    // an error is shown: "The VPN session failed because an internal error occurred".
-    // This forces the user to wait a few seconds before they can toggle the VPN back on.
-    @State private var waitCleanup = false
-    private var waitCleanupDuration: Duration = .seconds(6)
-
     let inspection = Inspection<Self>()
 
     var body: some View {
@@ -23,7 +16,7 @@ struct VPNMenu<VPN: VPNService>: View {
                     Toggle(isOn: Binding(
                         get: { vpn.state == .connected || vpn.state == .connecting },
                         set: { isOn in Task {
-                            if isOn { await vpn.start() } else { await stop() }
+                            if isOn { await vpn.start() } else { await vpn.stop() }
                         }
                         }
                     )) {
@@ -93,20 +86,10 @@ struct VPNMenu<VPN: VPNService>: View {
     }
 
     private var vpnDisabled: Bool {
-        waitCleanup ||
-            !state.hasSession ||
+        !session.hasSession ||
             vpn.state == .connecting ||
             vpn.state == .disconnecting ||
             vpn.state == .failed(.systemExtensionError(.needsUserApproval))
-    }
-
-    private func stop() async {
-        await vpn.stop()
-        waitCleanup = true
-        Task {
-            try? await Task.sleep(for: waitCleanupDuration)
-            waitCleanup = false
-        }
     }
 }
 

--- a/Coder Desktop/VPN/Manager.swift
+++ b/Coder Desktop/VPN/Manager.swift
@@ -27,7 +27,10 @@ actor Manager {
             fatalError("unknown architecture")
         #endif
         do {
-            try await download(src: dylibPath, dest: dest)
+            let sessionConfig = URLSessionConfiguration.default
+            // The tunnel might be asked to start before the network interfaces have woken up from sleep
+            sessionConfig.waitsForConnectivity = true
+            try await download(src: dylibPath, dest: dest, urlSession: URLSession(configuration: sessionConfig))
         } catch {
             throw .download(error)
         }

--- a/Coder Desktop/VPNLib/Download.swift
+++ b/Coder Desktop/VPNLib/Download.swift
@@ -101,7 +101,7 @@ public class SignatureValidator {
     }
 }
 
-public func download(src: URL, dest: URL) async throws(DownloadError) {
+public func download(src: URL, dest: URL, urlSession: URLSession) async throws(DownloadError) {
     var req = URLRequest(url: src)
     if FileManager.default.fileExists(atPath: dest.path) {
         if let existingFileData = try? Data(contentsOf: dest, options: .mappedIfSafe) {
@@ -112,7 +112,7 @@ public func download(src: URL, dest: URL) async throws(DownloadError) {
     let tempURL: URL
     let response: URLResponse
     do {
-        (tempURL, response) = try await URLSession.shared.download(for: req)
+        (tempURL, response) = try await urlSession.download(for: req)
     } catch {
         throw .networkError(error)
     }

--- a/Coder Desktop/VPNLibTests/DownloadTests.swift
+++ b/Coder Desktop/VPNLibTests/DownloadTests.swift
@@ -13,7 +13,7 @@ struct DownloadTests {
         let fileURL = URL(string: "http://example.com/test1.txt")!
         Mock(url: fileURL, contentType: .html, statusCode: 200, data: [.get: testData]).register()
 
-        try await download(src: fileURL, dest: destinationURL)
+        try await download(src: fileURL, dest: destinationURL, urlSession: URLSession.shared)
 
         try #require(FileManager.default.fileExists(atPath: destinationURL.path))
         defer { try? FileManager.default.removeItem(at: destinationURL) }
@@ -32,7 +32,7 @@ struct DownloadTests {
 
         Mock(url: fileURL, contentType: .html, statusCode: 200, data: [.get: testData]).register()
 
-        try await download(src: fileURL, dest: destinationURL)
+        try await download(src: fileURL, dest: destinationURL, urlSession: URLSession.shared)
         try #require(FileManager.default.fileExists(atPath: destinationURL.path))
         let downloadedData = try Data(contentsOf: destinationURL)
         #expect(downloadedData == testData)
@@ -44,7 +44,7 @@ struct DownloadTests {
         }
         mock.register()
 
-        try await download(src: fileURL, dest: destinationURL)
+        try await download(src: fileURL, dest: destinationURL, urlSession: URLSession.shared)
         let unchangedData = try Data(contentsOf: destinationURL)
         #expect(unchangedData == testData)
         #expect(etagIncluded)
@@ -61,7 +61,7 @@ struct DownloadTests {
 
         Mock(url: fileURL, contentType: .html, statusCode: 200, data: [.get: ogData]).register()
 
-        try await download(src: fileURL, dest: destinationURL)
+        try await download(src: fileURL, dest: destinationURL, urlSession: URLSession.shared)
         try #require(FileManager.default.fileExists(atPath: destinationURL.path))
         var downloadedData = try Data(contentsOf: destinationURL)
         #expect(downloadedData == ogData)
@@ -73,7 +73,7 @@ struct DownloadTests {
         }
         mock.register()
 
-        try await download(src: fileURL, dest: destinationURL)
+        try await download(src: fileURL, dest: destinationURL, urlSession: URLSession.shared)
         downloadedData = try Data(contentsOf: destinationURL)
         #expect(downloadedData == newData)
         #expect(etagIncluded)


### PR DESCRIPTION
Depends on https://github.com/coder/coder/pull/16598.
Reverts #43.

Whilst everything seems to recover okay tailnet wise when waking from sleep currently, the tunnel will still miss workspace/peer updates during the sleep, causing the workspace state in the UI to be out of sync with reality. 

To handle this, we'll teardown the tunnel on sleep, and bring it back up on wake.

Fixing the issue in `coder/coder` also revealed that the error encountered when toggling the VPN on and off quickly was another symptom, and so this change reverts the code that prevents toggling the VPN on and off quickly, as it now works flawlessly.