### PR TITLE
ci: add concurrency groups to release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: read
 
+# Cancel in-progress runs for pull requests when developers push
+# additional changes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test:
     name: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,12 @@ on:
 
 permissions: {}
 
+# Cancel in-progress runs for when multiple PRs get merged
+# in quickl succession. Ignore this for tag releases though.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'tags/')}}
+
 jobs:
   build:
     name: Build Coder Desktop


### PR DESCRIPTION
Add concurrency groups to GitHub Actions workflows

Adds concurrency groups to CI and release workflows to automatically cancel
in-progress runs when new changes are pushed. This prevents unnecessary
resource usage and speeds up feedback loops for developers.

Change-Id: I781ce2750eb30729e84430ee2e3855f3259d2eb9
Signed-off-by: Thomas Kosiewski <tk@coder.com>