### PR TITLE
chore: reduce error verbosity

### DIFF
--- a/Coder Desktop/Coder Desktop/Views/LoginForm.swift
+++ b/Coder Desktop/Coder Desktop/Views/LoginForm.swift
@@ -201,7 +201,7 @@ enum LoginError: Error {
         case .invalidURL:
             "Invalid URL"
         case let .failedAuth(err):
-            "Could not authenticate with Coder deployment:\n\(err.description)"
+            "Could not authenticate with Coder deployment:\n\(err.localizedDescription)"
         }
     }
 

--- a/Coder Desktop/CoderSDK/Client.swift
+++ b/Coder Desktop/CoderSDK/Client.swift
@@ -131,7 +131,7 @@ public enum ClientError: Error {
         case let .unexpectedResponse(data):
             "Unexpected or non HTTP response: \(data)"
         case let .encodeFailure(error):
-            "Failed to encode body: \(error)"
+            "Failed to encode body: \(error.localizedDescription)"
         }
     }
 

--- a/Coder Desktop/VPN/Manager.swift
+++ b/Coder Desktop/VPN/Manager.swift
@@ -251,17 +251,17 @@ enum ManagerError: Error {
     var description: String {
         switch self {
         case let .download(err):
-            "Download error: \(err)"
+            "Download error: \(err.localizedDescription)"
         case let .tunnelSetup(err):
-            "Tunnel setup error: \(err)"
+            "Tunnel setup error: \(err.localizedDescription)"
         case let .handshake(err):
-            "Handshake error: \(err)"
+            "Handshake error: \(err.localizedDescription)"
         case let .validation(err):
-            "Validation error: \(err)"
+            "Validation error: \(err.localizedDescription)"
         case .incorrectResponse:
             "Received unexpected response over tunnel"
         case let .failedRPC(err):
-            "Failed rpc: \(err)"
+            "Failed rpc: \(err.localizedDescription)"
         case let .serverInfo(msg):
             msg
         case let .errorResponse(msg):
@@ -273,7 +273,7 @@ enum ManagerError: Error {
         case .permissionDenied:
             "Permission was not granted to execute the CoderVPN dylib"
         case let .tunnelFail(err):
-            "Failed to communicate with dylib over tunnel: \(err)"
+            "Failed to communicate with dylib over tunnel: \(err.localizedDescription)"
         }
     }
 

--- a/Coder Desktop/VPN/TunnelHandle.swift
+++ b/Coder Desktop/VPN/TunnelHandle.swift
@@ -75,7 +75,7 @@ enum TunnelHandleError: Error {
 
     var description: String {
         switch self {
-        case let .pipe(err): "pipe error: \(err)"
+        case let .pipe(err): "pipe error: \(err.localizedDescription)"
         case let .dylib(d): d
         case let .symbol(symbol, message): "\(symbol): \(message)"
         case let .openTunnel(error): "OpenTunnel: \(error.message)"

--- a/Coder Desktop/VPNLib/Download.swift
+++ b/Coder Desktop/VPNLib/Download.swift
@@ -116,7 +116,7 @@ public func download(src: URL, dest: URL, urlSession: URLSession) async throws(D
     do {
         (tempURL, response) = try await urlSession.download(for: req)
     } catch {
-        throw .networkError(error)
+        throw .networkError(error, url: src.absoluteString)
     }
     defer {
         if FileManager.default.fileExists(atPath: tempURL.path) {
@@ -155,15 +155,15 @@ func etag(data: Data) -> String {
 public enum DownloadError: Error {
     case unexpectedStatusCode(Int)
     case invalidResponse
-    case networkError(any Error)
+    case networkError(any Error, url: String)
     case fileOpError(any Error)
 
     public var description: String {
         switch self {
         case let .unexpectedStatusCode(code):
             "Unexpected HTTP status code: \(code)"
-        case let .networkError(error):
-            "Network error: \(error.localizedDescription)"
+        case let .networkError(error, url):
+            "Network error: \(url) - \(error.localizedDescription)"
         case let .fileOpError(error):
             "File operation error: \(error.localizedDescription)"
         case .invalidResponse:


### PR DESCRIPTION
Before & After:
![image](https://github.com/user-attachments/assets/6f05acb4-ff31-4163-a653-a16a569736e9)

We always want to show the `localizedDescription`, and rarely anything else. These long errors make for a pretty poor UX. Logs are unchanged.