### PR TITLE
chore: improve text contrast on light mode

### DIFF
--- a/Coder Desktop/Coder Desktop/VPNMenuState.swift
+++ b/Coder Desktop/Coder Desktop/VPNMenuState.swift
@@ -33,7 +33,7 @@ enum AgentStatus: Int, Equatable, Comparable {
         case .okay: .green
         case .warn: .yellow
         case .error: .red
-        case .off: .gray
+        case .off: .secondary
         }
     }
 

--- a/Coder Desktop/Coder Desktop/Views/Agents.swift
+++ b/Coder Desktop/Coder Desktop/Views/Agents.swift
@@ -21,7 +21,7 @@ struct Agents<VPN: VPNService>: View {
                 if items.count == 0 {
                     Text("No workspaces!")
                         .font(.body)
-                        .foregroundColor(.gray)
+                        .foregroundColor(.secondary)
                         .padding(.horizontal, Theme.Size.trayInset)
                         .padding(.top, 2)
                 }
@@ -30,7 +30,7 @@ struct Agents<VPN: VPNService>: View {
                     Toggle(isOn: $viewAll) {
                         Text(viewAll ? "Show less" : "Show all")
                             .font(.headline)
-                            .foregroundColor(.gray)
+                            .foregroundColor(.secondary)
                             .padding(.horizontal, Theme.Size.trayInset)
                             .padding(.top, 2)
                     }.toggleStyle(.button).buttonStyle(.plain)

--- a/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
@@ -30,7 +30,7 @@ struct VPNMenu<VPN: VPNService>: View {
                 Divider()
                 Text("Workspaces")
                     .font(.headline)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
                 VPNState<VPN>()
             }.padding([.horizontal, .top], Theme.Size.trayInset)
             Agents<VPN>()

--- a/Coder Desktop/Coder Desktop/Views/VPNMenuItem.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNMenuItem.swift
@@ -56,7 +56,7 @@ struct MenuItemView: View {
         var formattedName = AttributedString(name)
         formattedName.foregroundColor = .primary
         if let range = formattedName.range(of: ".coder") {
-            formattedName[range].foregroundColor = .gray
+            formattedName[range].foregroundColor = .secondary
         }
         return formattedName
     }

--- a/Coder Desktop/Coder Desktop/Views/VPNState.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNState.swift
@@ -12,15 +12,15 @@ struct VPNState<VPN: VPNService>: View {
             case (.failed(.systemExtensionError(.needsUserApproval)), _):
                 Text("Awaiting System Extension approval")
                     .font(.body)
-                    .foregroundStyle(.gray)
+                    .foregroundStyle(.secondary)
             case (_, false):
                 Text("Sign in to use CoderVPN")
                     .font(.body)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.secondary)
             case (.disabled, _):
                 Text("Enable CoderVPN to see workspaces")
                     .font(.body)
-                    .foregroundStyle(.gray)
+                    .foregroundStyle(.secondary)
             case (.connecting, _), (.disconnecting, _):
                 HStack {
                     Spacer()


### PR DESCRIPTION
I discovered you pretty much never want to use `gray` as a text colour. `secondary` is only gray where appropriate.
The menu bar tray is slightly transparent, and `.secondary` and `.primary` text colours account for that.
As seen below, dark mode is almost unchanged.


## Light Mode

### Before (on a dark background)
![image](https://github.com/user-attachments/assets/c820ae9b-7bfb-4caa-bf46-a3e88c8774ff) ![image](https://github.com/user-attachments/assets/77d06c06-28d5-43ad-85bc-c7ece2ed77cc)

### After (on a dark background)
![image](https://github.com/user-attachments/assets/d4e1ca40-1bc4-4624-800a-97c772fa4b2d) ![image](https://github.com/user-attachments/assets/e496d22b-40bb-4734-a761-842b779a430c)

Note: Apple's decided to make `secondary` darker than `primary` in this case.

### After (on a light background)
![image](https://github.com/user-attachments/assets/d7b0401f-871d-4357-b994-b0b8445a3897) ![image](https://github.com/user-attachments/assets/475bf25f-e4c4-41b7-82ec-78aca90c51ea)

## Dark Mode

### Before
![image](https://github.com/user-attachments/assets/c8b6b6db-abf0-44e0-8882-0c4d81330977) ![image](https://github.com/user-attachments/assets/e0c06b80-eefe-41be-84a4-902a65124807)

### After
![image](https://github.com/user-attachments/assets/2e00bb6d-f4f5-472e-b1dd-7f8f37622500) ![image](https://github.com/user-attachments/assets/e2055106-2c29-475b-b342-bdbf88af3194)






