### PR TITLE
ci: Fix homebrew cask styling

### DIFF
--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -107,18 +107,18 @@ cask "coder-desktop${SUFFIX}" do
 
   app "Coder Desktop.app"
 
-  uninstall quit: [
+  uninstall quit:       [
               "com.coder.Coder-Desktop",
               "com.coder.Coder-Desktop.VPN",
             ],
             login_item: "Coder Desktop"
 
-  zap trash: [
+  zap delete: "/var/root/Library/Containers/com.Coder-Desktop.VPN/Data/Documents/coder-vpn.dylib",
+      trash:  [
         "~/Library/Caches/com.coder.Coder-Desktop",
         "~/Library/HTTPStorages/com.coder.Coder-Desktop",
         "~/Library/Preferences/com.coder.Coder-Desktop.plist",
-      ],
-      delete: "/var/root/Library/Containers/com.Coder-Desktop.VPN/Data/Documents/coder-vpn.dylib"
+      ]
 end
 EOF
 


### PR DESCRIPTION
Fix homebrew cask styling, as it complained about incorrectly ordered keys and spacing.

Change-Id: I02234e007ce2f37074779211ab6c102cb4213122
Signed-off-by: Thomas Kosiewski <tk@coder.com>
