### PR TITLE
fix: canvas preview panic in Xcode resolved

### DIFF
--- a/Coder Desktop/Coder Desktop/State.swift
+++ b/Coder Desktop/Coder Desktop/State.swift
@@ -25,6 +25,7 @@ class AppState: ObservableObject {
     // Stored in Keychain
     @Published private(set) var sessionToken: String? {
         didSet {
+            guard persistent else { return }
             keychainSet(sessionToken, for: Keys.sessionToken)
         }
     }

--- a/Coder Desktop/Coder Desktop/Views/LoginForm.swift
+++ b/Coder Desktop/Coder Desktop/Views/LoginForm.swift
@@ -221,6 +221,6 @@ enum LoginField: Hashable {
 #if DEBUG
     #Preview {
         LoginForm()
-            .environmentObject(AppState())
+            .environmentObject(AppState(persistent: false))
     }
 #endif

--- a/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
@@ -104,8 +104,12 @@ func openSystemExtensionSettings() {
 
 #if DEBUG
     #Preview {
-        VPNMenu<PreviewVPN>().frame(width: 256)
+        let appState = AppState(persistent: false)
+        appState.login(baseAccessURL: URL(string: "http://127.0.0.1:8080")!, sessionToken: "")
+        // appState.clearSession()
+
+        return VPNMenu<PreviewVPN>().frame(width: 256)
             .environmentObject(PreviewVPN())
-            .environmentObject(AppState(persistent: false))
+            .environmentObject(appState)
     }
 #endif


### PR DESCRIPTION
The preview was panicking because the app state had an optional base URL, which is getting unwrapped elsewhere. This creates an app state and then 'logs in' to set the base URL, reenabling the preview.

Change-Id: I8d6a19063a13f772dc409bc5e523e1af9c109bee
Signed-off-by: Thomas Kosiewski <tk@coder.com>