### PR TITLE
chore: remove "VPN" from setting description

### DIFF
--- a/Coder Desktop/Coder Desktop/NetworkExtension.swift
+++ b/Coder Desktop/Coder Desktop/NetworkExtension.swift
@@ -50,7 +50,7 @@ extension CoderVPNService {
         logger.debug("inserting new tunnel")
 
         let tm = NETunnelProviderManager()
-        tm.localizedDescription = "CoderVPN"
+        tm.localizedDescription = "Coder"
         tm.protocolConfiguration = proto
 
         logger.debug("saving new tunnel")

--- a/Coder Desktop/Coder Desktop/SystemExtension.swift
+++ b/Coder Desktop/Coder Desktop/SystemExtension.swift
@@ -11,13 +11,13 @@ enum SystemExtensionState: Equatable, Sendable {
     var description: String {
         switch self {
         case .uninstalled:
-            "VPN SystemExtension is waiting to be activated"
+            "NE SystemExtension is waiting to be activated"
         case .needsUserApproval:
-            "VPN SystemExtension needs user approval to activate"
+            "NE SystemExtension needs user approval to activate"
         case .installed:
-            "VPN SystemExtension is installed"
+            "NE SystemExtension is installed"
         case let .failed(error):
-            "VPN SystemExtension failed with error: \(error)"
+            "NE SystemExtension failed with error: \(error)"
         }
     }
 }

--- a/Coder Desktop/Coder Desktop/Views/Settings/GeneralTab.swift
+++ b/Coder Desktop/Coder Desktop/Views/Settings/GeneralTab.swift
@@ -10,7 +10,7 @@ struct GeneralTab: View {
             }
             Section {
                 Toggle(isOn: $state.stopVPNOnQuit) {
-                    Text("Stop VPN on Quit")
+                    Text("Stop Coder Connect on Quit")
                 }
             }
         }.formStyle(.grouped)

--- a/Coder Desktop/Coder Desktop/Views/Settings/LiteralHeadersSection.swift
+++ b/Coder Desktop/Coder Desktop/Views/Settings/LiteralHeadersSection.swift
@@ -15,7 +15,7 @@ struct LiteralHeadersSection<VPN: VPNService>: View {
             Toggle(isOn: $state.useLiteralHeaders) {
                 Text("HTTP Headers")
                 Text("When enabled, these headers will be included on all outgoing HTTP requests.")
-                if vpn.state != .disabled { Text("Cannot be modified while Coder VPN is enabled.") }
+                if vpn.state != .disabled { Text("Cannot be modified while Coder Connect is enabled.") }
             }
             .controlSize(.large)
 

--- a/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNMenu.swift
@@ -20,7 +20,7 @@ struct VPNMenu<VPN: VPNService>: View {
                         }
                         }
                     )) {
-                        Text("CoderVPN")
+                        Text("Coder Connect")
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .font(.body.bold())
                             .foregroundColor(.primary)

--- a/Coder Desktop/Coder Desktop/Views/VPNState.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNState.swift
@@ -14,18 +14,18 @@ struct VPNState<VPN: VPNService>: View {
                     .font(.body)
                     .foregroundStyle(.secondary)
             case (_, false):
-                Text("Sign in to use CoderVPN")
+                Text("Sign in to use Coder Desktop")
                     .font(.body)
                     .foregroundColor(.secondary)
             case (.disabled, _):
-                Text("Enable CoderVPN to see workspaces")
+                Text("Enable Coder Connect to see workspaces")
                     .font(.body)
                     .foregroundStyle(.secondary)
             case (.connecting, _), (.disconnecting, _):
                 HStack {
                     Spacer()
                     ProgressView(
-                        vpn.state == .connecting ? "Starting CoderVPN..." : "Stopping CoderVPN..."
+                        vpn.state == .connecting ? "Starting Coder Connect..." : "Stopping Coder Connect..."
                     ).padding()
                     Spacer()
                 }

--- a/Coder Desktop/Coder DesktopTests/VPNMenuTests.swift
+++ b/Coder Desktop/Coder DesktopTests/VPNMenuTests.swift
@@ -24,7 +24,7 @@ struct VPNMenuTests {
             try await sut.inspection.inspect { view in
                 let toggle = try view.find(ViewType.Toggle.self)
                 #expect(toggle.isDisabled())
-                #expect(throws: Never.self) { try view.find(text: "Sign in to use CoderVPN") }
+                #expect(throws: Never.self) { try view.find(text: "Sign in to use Coder Desktop") }
                 #expect(throws: Never.self) { try view.find(button: "Sign in") }
             }
         }

--- a/Coder Desktop/Coder DesktopTests/VPNStateTests.swift
+++ b/Coder Desktop/Coder DesktopTests/VPNStateTests.swift
@@ -26,7 +26,7 @@ struct VPNStateTests {
         try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 #expect(throws: Never.self) {
-                    try view.find(text: "Enable CoderVPN to see workspaces")
+                    try view.find(text: "Enable Coder Connect to see workspaces")
                 }
             }
         }
@@ -39,7 +39,7 @@ struct VPNStateTests {
         try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 let progressView = try view.find(ViewType.ProgressView.self)
-                #expect(try progressView.labelView().text().string() == "Starting CoderVPN...")
+                #expect(try progressView.labelView().text().string() == "Starting Coder Connect...")
             }
         }
     }
@@ -51,7 +51,7 @@ struct VPNStateTests {
         try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 let progressView = try view.find(ViewType.ProgressView.self)
-                #expect(try progressView.labelView().text().string() == "Stopping CoderVPN...")
+                #expect(try progressView.labelView().text().string() == "Stopping Coder Connect...")
             }
         }
     }

--- a/pkgbuild/scripts/postinstall
+++ b/pkgbuild/scripts/postinstall
@@ -16,7 +16,7 @@ if [ -f "$VPN_MARKER_FILE" ]; then
   echo "Restarting CoderVPN..."
   echo "Sleeping for 3..."
   sleep 3
-  scutil --nc start "CoderVPN"
+  scutil --nc start "Coder"
   rm "$VPN_MARKER_FILE"
   echo "CoderVPN started."
 fi

--- a/pkgbuild/scripts/preinstall
+++ b/pkgbuild/scripts/preinstall
@@ -10,19 +10,19 @@ if pgrep 'Coder Desktop'; then
 fi
 
 echo "Turning off VPN"
-if scutil --nc list | grep -q "CoderVPN"; then
+if scutil --nc list | grep -q "Coder"; then
   echo "CoderVPN found. Stopping..."
-  if scutil --nc status "CoderVPN" | grep -q "^Connected$"; then
+  if scutil --nc status "Coder" | grep -q "^Connected$"; then
     touch $VPN_MARKER_FILE
   fi
-  scutil --nc stop "CoderVPN"
+  scutil --nc stop "Coder"
 
   # Wait for VPN to be disconnected
-  while scutil --nc status "CoderVPN" | grep -q "^Connected$"; do
+  while scutil --nc status "Coder" | grep -q "^Connected$"; do
     echo "Waiting for VPN to disconnect..."
     sleep 1
   done
-  while scutil --nc status "CoderVPN" | grep -q "^Disconnecting$"; do
+  while scutil --nc status "Coder" | grep -q "^Disconnecting$"; do
     echo "Waiting for VPN to complete disconnect..."
     sleep 1
   done


### PR DESCRIPTION
Rename "CoderVPN" to "Coder Connect" in UI and system components

- Updates VPN-related text from "CoderVPN" to "Coder Connect" in UI components
- Changes network extension references from "VPN" to "NE" in system messages
- Updates VPN tunnel name from "CoderVPN" to "Coder" in network configuration
- Modifies installation scripts to use "Coder" as the VPN service name
