### PR TITLE
fix: make copy button padding clickable

### DIFF
--- a/Coder Desktop/Coder Desktop/Views/VPNMenuItem.swift
+++ b/Coder Desktop/Coder Desktop/Views/VPNMenuItem.swift
@@ -97,6 +97,7 @@ struct MenuItemView: View {
                     Image(systemName: "doc.on.doc")
                         .symbolVariant(.fill)
                         .padding(3)
+                        .contentShape(Rectangle())
                 }.foregroundStyle(copyIsSelected ? .white : .primary)
                     .imageScale(.small)
                     .background(copyIsSelected ? Color.accentColor.opacity(0.8) : .clear)


### PR DESCRIPTION
Previously, if you clicked on the highlighted padding of the copy icon, the button wouldn't get pressed - this was really bothering me.
[Relevant.](https://www.hackingwithswift.com/quick-start/swiftui/how-to-control-the-tappable-area-of-a-view-using-contentshape)