### PR TITLE
chore: enforce minimum coder server version of v2.20.0

### DIFF
--- a/Coder Desktop/Coder DesktopTests/LoginFormTests.swift
+++ b/Coder Desktop/Coder DesktopTests/LoginFormTests.swift
@@ -73,6 +73,14 @@ struct LoginTests {
     @Test
     func testFailedAuthentication() async throws {
         let url = URL(string: "https://testFailedAuthentication.com")!
+        let buildInfo = BuildInfoResponse(
+            version: "v2.20.0"
+        )
+        try Mock(
+            url: url.appendingPathComponent("/api/v2/buildinfo"),
+            statusCode: 200,
+            data: [.get: Client.encoder.encode(buildInfo)]
+        ).register()
         Mock(url: url.appendingPathComponent("/api/v2/users/me"), statusCode: 401, data: [.get: Data()]).register()
 
         try await ViewHosting.host(view) {
@@ -95,11 +103,20 @@ struct LoginTests {
             id: UUID(),
             username: "admin"
         )
+        let buildInfo = BuildInfoResponse(
+            version: "v2.20.0"
+        )
 
         try Mock(
             url: url.appendingPathComponent("/api/v2/users/me"),
             statusCode: 200,
             data: [.get: Client.encoder.encode(user)]
+        ).register()
+
+        try Mock(
+            url: url.appendingPathComponent("/api/v2/buildinfo"),
+            statusCode: 200,
+            data: [.get: Client.encoder.encode(buildInfo)]
         ).register()
 
         try await ViewHosting.host(view) {

--- a/Coder Desktop/Coder DesktopTests/LoginFormTests.swift
+++ b/Coder Desktop/Coder DesktopTests/LoginFormTests.swift
@@ -96,6 +96,30 @@ struct LoginTests {
     }
 
     @Test
+    func testOutdatedServer() async throws {
+        let url = URL(string: "https://testOutdatedServer.com")!
+        let buildInfo = BuildInfoResponse(
+            version: "v2.19.0"
+        )
+        try Mock(
+            url: url.appendingPathComponent("/api/v2/buildinfo"),
+            statusCode: 200,
+            data: [.get: Client.encoder.encode(buildInfo)]
+        ).register()
+
+        try await ViewHosting.host(view) {
+            try await sut.inspection.inspect { view in
+                try view.find(ViewType.TextField.self).setInput(url.absoluteString)
+                try view.find(button: "Next").tap()
+                #expect(throws: Never.self) { try view.find(text: "Session Token") }
+                try view.find(ViewType.SecureField.self).setInput("valid-token")
+                try await view.actualView().submit()
+                #expect(throws: Never.self) { try view.find(ViewType.Alert.self) }
+            }
+        }
+    }
+
+    @Test
     func testSuccessfulLogin() async throws {
         let url = URL(string: "https://testSuccessfulLogin.com")!
 

--- a/Coder Desktop/VPN/Manager.swift
+++ b/Coder Desktop/VPN/Manager.swift
@@ -31,9 +31,9 @@ actor Manager {
             // The tunnel might be asked to start before the network interfaces have woken up from sleep
             sessionConfig.waitsForConnectivity = true
             // URLSession's waiting for connectivity sometimes hangs even when
-            // the network is up so this is deliberately short (15s) to avoid a
+            // the network is up so this is deliberately short (30s) to avoid a
             // poor UX where it appears stuck.
-            sessionConfig.timeoutIntervalForResource = 15
+            sessionConfig.timeoutIntervalForResource = 30
             try await download(src: dylibPath, dest: dest, urlSession: URLSession(configuration: sessionConfig))
         } catch {
             throw .download(error)

--- a/Coder Desktop/VPNLib/Download.swift
+++ b/Coder Desktop/VPNLib/Download.swift
@@ -31,7 +31,10 @@ public enum ValidationError: Error {
         case .missingInfoPList:
             "Info.plist is not embedded within the dylib."
         case .belowMinimumCoderVersion:
-            "The Coder deployment must be version \(SignatureValidator.minimumCoderVersion) or higher to use Coder Desktop."
+            """
+            The Coder deployment must be version \(SignatureValidator.minimumCoderVersion)
+            or higher to use Coder Desktop.
+            """
         }
     }
 
@@ -53,6 +56,7 @@ public class SignatureValidator {
     private static let signInfoFlags: SecCSFlags = .init(rawValue: kSecCSSigningInformation)
 
     // `expectedVersion` must be of the form `[0-9]+.[0-9]+.[0-9]+`
+    // swiftlint:disable:next cyclomatic_complexity
     public static func validate(path: URL, expectedVersion: String) throws(ValidationError) {
         guard FileManager.default.fileExists(atPath: path.path) else {
             throw .fileNotFound

--- a/Coder Desktop/VPNLib/Download.swift
+++ b/Coder Desktop/VPNLib/Download.swift
@@ -56,7 +56,6 @@ public class SignatureValidator {
     private static let signInfoFlags: SecCSFlags = .init(rawValue: kSecCSSigningInformation)
 
     // `expectedVersion` must be of the form `[0-9]+.[0-9]+.[0-9]+`
-    // swiftlint:disable:next cyclomatic_complexity
     public static func validate(path: URL, expectedVersion: String) throws(ValidationError) {
         guard FileManager.default.fileExists(atPath: path.path) else {
             throw .fileNotFound
@@ -97,6 +96,10 @@ public class SignatureValidator {
             throw .missingInfoPList
         }
 
+        try validateInfo(infoPlist: infoPlist, expectedVersion: expectedVersion)
+    }
+
+    private static func validateInfo(infoPlist: [String: AnyObject], expectedVersion: String) throws(ValidationError) {
         guard let plistIdent = infoPlist[infoIdentifierKey] as? String, plistIdent == expectedIdentifier else {
             throw .invalidIdentifier(identifier: infoPlist[infoIdentifierKey] as? String)
         }

--- a/Coder Desktop/VPNLib/Download.swift
+++ b/Coder Desktop/VPNLib/Download.swift
@@ -43,7 +43,7 @@ public enum ValidationError: Error {
 
 public class SignatureValidator {
     // Whilst older dylibs exist, this app assumes v2.20 or later.
-    static let minimumCoderVersion = "2.20.0"
+    public static let minimumCoderVersion = "2.20.0"
 
     private static let expectedName = "CoderVPN"
     private static let expectedIdentifier = "com.coder.Coder-Desktop.VPN.dylib"


### PR DESCRIPTION
This will cause Coder Desktop networking to fail to start unless the validated dylib is version `v2.20.0` or later. Obviously, using this build early would mean Coder Desktop would not work against our dogfood deployment.