### PR TITLE
fix: handle missing user `theme_preference` on sign in

### DIFF
--- a/Coder Desktop/Coder DesktopTests/LoginFormTests.swift
+++ b/Coder Desktop/Coder DesktopTests/LoginFormTests.swift
@@ -93,18 +93,7 @@ struct LoginTests {
 
         let user = User(
             id: UUID(),
-            username: "admin",
-            avatar_url: "",
-            name: "admin",
-            email: "admin@coder.com",
-            created_at: Date.now,
-            updated_at: Date.now,
-            last_seen_at: Date.now,
-            status: "active",
-            login_type: "none",
-            theme_preference: "dark",
-            organization_ids: [],
-            roles: []
+            username: "admin"
         )
 
         try Mock(

--- a/Coder Desktop/CoderSDK/Deployment.swift
+++ b/Coder Desktop/CoderSDK/Deployment.swift
@@ -10,16 +10,8 @@ public extension Client {
     }
 }
 
-public struct BuildInfoResponse: Encodable, Decodable, Equatable, Sendable {
-    public let external_url: String
+public struct BuildInfoResponse: Codable, Equatable, Sendable {
     public let version: String
-    public let dashboard_url: String
-    public let telemetry: Bool
-    public let workspace_proxy: Bool
-    public let agent_api_version: String
-    public let provisioner_api_version: String
-    public let upgrade_message: String
-    public let deployment_id: String
 
     // `version` in the form `[0-9]+.[0-9]+.[0-9]+`
     public var semver: String? {

--- a/Coder Desktop/CoderSDK/Deployment.swift
+++ b/Coder Desktop/CoderSDK/Deployment.swift
@@ -6,11 +6,7 @@ public extension Client {
         guard res.resp.statusCode == 200 else {
             throw responseAsError(res)
         }
-        do {
-            return try Client.decoder.decode(BuildInfoResponse.self, from: res.data)
-        } catch {
-            throw .unexpectedResponse(res.data.prefix(1024))
-        }
+        return try decode(BuildInfoResponse.self, from: res.data)
     }
 }
 

--- a/Coder Desktop/CoderSDK/User.swift
+++ b/Coder Desktop/CoderSDK/User.swift
@@ -6,57 +6,20 @@ public extension Client {
         guard res.resp.statusCode == 200 else {
             throw responseAsError(res)
         }
-        do {
-            return try Client.decoder.decode(User.self, from: res.data)
-        } catch {
-            throw .unexpectedResponse(res.data.prefix(1024))
-        }
+        return try decode(User.self, from: res.data)
     }
 }
 
 public struct User: Encodable, Decodable, Equatable, Sendable {
     public let id: UUID
     public let username: String
-    public let avatar_url: String
-    public let name: String
-    public let email: String
-    public let created_at: Date
-    public let updated_at: Date
-    public let last_seen_at: Date
-    public let status: String
-    public let login_type: String
-    public let theme_preference: String
-    public let organization_ids: [UUID]
-    public let roles: [Role]
 
     public init(
         id: UUID,
-        username: String,
-        avatar_url: String,
-        name: String,
-        email: String,
-        created_at: Date,
-        updated_at: Date,
-        last_seen_at: Date,
-        status: String,
-        login_type: String,
-        theme_preference: String,
-        organization_ids: [UUID],
-        roles: [Role]
+        username: String
     ) {
         self.id = id
         self.username = username
-        self.avatar_url = avatar_url
-        self.name = name
-        self.email = email
-        self.created_at = created_at
-        self.updated_at = updated_at
-        self.last_seen_at = last_seen_at
-        self.status = status
-        self.login_type = login_type
-        self.theme_preference = theme_preference
-        self.organization_ids = organization_ids
-        self.roles = roles
     }
 }
 

--- a/Coder Desktop/CoderSDK/User.swift
+++ b/Coder Desktop/CoderSDK/User.swift
@@ -22,15 +22,3 @@ public struct User: Encodable, Decodable, Equatable, Sendable {
         self.username = username
     }
 }
-
-public struct Role: Encodable, Decodable, Equatable, Sendable {
-    public let name: String
-    public let display_name: String
-    public let organization_id: UUID?
-
-    public init(name: String, display_name: String, organization_id: UUID?) {
-        self.name = name
-        self.display_name = display_name
-        self.organization_id = organization_id
-    }
-}

--- a/Coder Desktop/CoderSDKTests/CoderSDKTests.swift
+++ b/Coder Desktop/CoderSDKTests/CoderSDKTests.swift
@@ -7,23 +7,9 @@ import Testing
 struct CoderSDKTests {
     @Test
     func user() async throws {
-        let now = Date.now
         let user = User(
             id: UUID(),
-            username: "johndoe",
-            avatar_url: "https://example.com/img.png",
-            name: "John Doe",
-            email: "john.doe@example.com",
-            created_at: now,
-            updated_at: now,
-            last_seen_at: now,
-            status: "active",
-            login_type: "email",
-            theme_preference: "dark",
-            organization_ids: [UUID()],
-            roles: [
-                Role(name: "user", display_name: "User", organization_id: UUID()),
-            ]
+            username: "johndoe"
         )
 
         let url = URL(string: "https://example.com")!
@@ -50,15 +36,7 @@ struct CoderSDKTests {
     @Test
     func buildInfo() async throws {
         let buildInfo = BuildInfoResponse(
-            external_url: "https://example.com",
-            version: "v2.18.2-devel+630fd7c0a",
-            dashboard_url: "https://example.com/dashboard",
-            telemetry: true,
-            workspace_proxy: false,
-            agent_api_version: "1.0",
-            provisioner_api_version: "1.2",
-            upgrade_message: "foo",
-            deployment_id: UUID().uuidString
+            version: "v2.18.2-devel+630fd7c0a"
         )
 
         let url = URL(string: "https://example.com")!


### PR DESCRIPTION
https://github.com/coder/coder/pull/16564 has the Coder server no longer send the `theme_preference` field  in a `/api/v2/user` response. 

The Swift `JSONDecoder` requires that a missing field be explicitly marked as optional, else the deserialization fails. To make it less likely this happens again, we'll only require `id` and `username` be present.
We'll do the same for the other SDK types and only require the minimum fields the app needs be present.

This PR also improves the error message on any decoding error:
<img width="259" alt="Screenshot 2025-03-06 at 1 35 33 pm" src="https://github.com/user-attachments/assets/0fef147c-29ad-41bf-9aff-29651ff6b796" />


