### PR TITLE
ci: fix cask update

### DIFF
--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -44,15 +44,15 @@ done
   exit 1
 }
 
-# Download the Coder Desktop dmg
+# Download the CoderDesktop pkg
 GH_RELEASE_FOLDER=$(mktemp -d)
 
 gh release download "$VERSION" \
   --repo coder/coder-desktop-macos \
   --dir "$GH_RELEASE_FOLDER" \
-  --pattern 'Coder.Desktop.dmg'
+  --pattern 'CoderDesktop.pkg'
 
-HASH=$(shasum -a 256 "$GH_RELEASE_FOLDER"/Coder.Desktop.dmg | awk '{print $1}' | tr -d '\n')
+HASH=$(shasum -a 256 "$GH_RELEASE_FOLDER"/CoderDesktop.pkg | awk '{print $1}' | tr -d '\n')
 
 IS_PREVIEW=false
 if [[ "$VERSION" == "preview" ]]; then


### PR DESCRIPTION
Update cask script to use pkg instead of dmg

Updates the update-cask script to download and verify the CoderDesktop.pkg file instead of the previously used Coder.Desktop.dmg file.

Change-Id: I79e601684c94374f62f505e6bdf86c51f7a42d7e
Signed-off-by: Thomas Kosiewski <tk@coder.com>
