### PR TITLE
feat: add start vpn on launch setting

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -58,6 +58,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if await !vpn.loadNetworkExtensionConfig() {
                 state.reconfigure()
             }
+            if state.startVPNOnLaunch {
+                await vpn.start()
+            }
         }
         // TODO: Start the daemon only once a file sync is configured
         Task {

--- a/Coder-Desktop/Coder-Desktop/State.swift
+++ b/Coder-Desktop/Coder-Desktop/State.swift
@@ -54,6 +54,13 @@ class AppState: ObservableObject {
         }
     }
 
+    @Published var startVPNOnLaunch: Bool = UserDefaults.standard.bool(forKey: Keys.startVPNOnLaunch) {
+        didSet {
+            guard persistent else { return }
+            UserDefaults.standard.set(startVPNOnLaunch, forKey: Keys.startVPNOnLaunch)
+        }
+    }
+
     func tunnelProviderProtocol() -> NETunnelProviderProtocol? {
         if !hasSession { return nil }
         let proto = NETunnelProviderProtocol()
@@ -133,6 +140,7 @@ class AppState: ObservableObject {
         static let useLiteralHeaders = "UseLiteralHeaders"
         static let literalHeaders = "LiteralHeaders"
         static let stopVPNOnQuit = "StopVPNOnQuit"
+        static let startVPNOnLaunch = "StartVPNOnLaunch"
     }
 }
 

--- a/Coder-Desktop/Coder-Desktop/Views/Settings/GeneralTab.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/Settings/GeneralTab.swift
@@ -6,11 +6,16 @@ struct GeneralTab: View {
     var body: some View {
         Form {
             Section {
-                LaunchAtLogin.Toggle("Launch at Login")
+                LaunchAtLogin.Toggle("Launch at login")
             }
             Section {
                 Toggle(isOn: $state.stopVPNOnQuit) {
-                    Text("Stop Coder Connect on Quit")
+                    Text("Stop Coder Connect on quit")
+                }
+            }
+            Section {
+                Toggle(isOn: $state.startVPNOnLaunch) {
+                    Text("Start Coder Connect on launch")
                 }
             }
         }.formStyle(.grouped)


### PR DESCRIPTION
Relates to #104.

On-demand is a pretty big lift - in the meantime we'll add a 'start VPN on launch' config setting.