### PR TITLE
chore: sign user out if token is expired

### DIFF
--- a/Coder-Desktop/CoderSDK/Client.swift
+++ b/Coder-Desktop/CoderSDK/Client.swift
@@ -104,10 +104,10 @@ public struct Client {
 }
 
 public struct APIError: Decodable, Sendable {
-    let response: Response
-    let statusCode: Int
-    let method: String
-    let url: URL
+    public let response: Response
+    public let statusCode: Int
+    public let method: String
+    public let url: URL
 
     var description: String {
         var components = ["\(method) \(url.absoluteString)\nUnexpected status code \(statusCode):\n\(response.message)"]

--- a/Coder-Desktop/project.yml
+++ b/Coder-Desktop/project.yml
@@ -92,10 +92,12 @@ packages:
     url: https://github.com/SimplyDanny/SwiftLintPlugins
     from: 0.57.1
   FluidMenuBarExtra:
-    # Forked so we can dynamically update the menu bar icon.
+    # Forked to:
+    # - Dynamically update the menu bar icon
+    # - Set onAppear/disappear handlers.
     # The upstream repo has a purposefully limited API
     url: https://github.com/coder/fluid-menu-bar-extra
-    revision: 020be37
+    revision: 96a861a
   KeychainAccess:
     url: https://github.com/kishikawakatsumi/KeychainAccess
     branch: e0c7eebc5a4465a3c4680764f26b7a61f567cdaf


### PR DESCRIPTION
Closes #107.

When the menu bar icon is clicked, and the user is signed in, and the VPN is disabled, the app will check if the token is expired. If it is, the user will be signed out.

We could have checked this when the VPN is enabled, but the UX seemed worse, and the implementation would have been messy. We would have needed to sign the user out and show an error. Instead, we'll check for expiry in a scenario where the next user step would likely be an interaction that requires a session. 
This approach also future-proofs for when functionality becomes usable without the VPN.