### PR TITLE
chore(pkgbuild): delete existing app during preinstall, `spctl --assess` during postinstall

### DIFF
--- a/pkgbuild/scripts/postinstall
+++ b/pkgbuild/scripts/postinstall
@@ -6,6 +6,10 @@ VPN_MARKER_FILE="/tmp/coder_vpn_was_running"
 # Before this script, or the user opens the app, make sure
 # Gatekeeper has ingested the notarization ticket.
 spctl -avvv "/Applications/Coder Desktop.app"
+# spctl can't assess non-apps, so this will always return a non-zero exit code, 
+# but the error message implies at minimum the signature of the extension was 
+# checked. 
+spctl -avvv "/Applications/Coder Desktop.app/Contents/Library/SystemExtensions/com.coder.Coder-Desktop.VPN.systemextension" || true
 
 # Restart Coder Desktop if it was running before
 if [ -f "$RUNNING_MARKER_FILE" ]; then

--- a/pkgbuild/scripts/postinstall
+++ b/pkgbuild/scripts/postinstall
@@ -3,6 +3,10 @@
 RUNNING_MARKER_FILE="/tmp/coder_desktop_running"
 VPN_MARKER_FILE="/tmp/coder_vpn_was_running"
 
+# Before this script, or the user opens the app, make sure
+# Gatekeeper has ingested the notarization ticket.
+spctl -avvv "/Applications/Coder Desktop.app"
+
 # Restart Coder Desktop if it was running before
 if [ -f "$RUNNING_MARKER_FILE" ]; then
   echo "Starting Coder Desktop..."

--- a/pkgbuild/scripts/postinstall
+++ b/pkgbuild/scripts/postinstall
@@ -3,7 +3,7 @@
 RUNNING_MARKER_FILE="/tmp/coder_desktop_running"
 VPN_MARKER_FILE="/tmp/coder_vpn_was_running"
 
-# Before this script, or the user opens the app, make sure
+# Before this script, or the user, opens the app, make sure
 # Gatekeeper has ingested the notarization ticket.
 spctl -avvv "/Applications/Coder Desktop.app"
 # spctl can't assess non-apps, so this will always return a non-zero exit code, 

--- a/pkgbuild/scripts/preinstall
+++ b/pkgbuild/scripts/preinstall
@@ -35,4 +35,11 @@ echo "Asking com.coder.Coder-Desktop to quit..."
 osascript -e 'if app id "com.coder.Coder-Desktop" is running then' -e 'quit app id "com.coder.Coder-Desktop"' -e 'end if'
 echo "Done."
 
+APP="/Applications/Coder Desktop.app"
+if [ -d "$APP" ]; then
+  echo "Deleting Coder Desktop..."
+  rm -rf "$APP"
+  echo "Done."
+fi
+
 exit 0


### PR DESCRIPTION
Relates to #83.

It looks like deleting the app does indeed kill the NE process, so we should do that during `preinstall`.

In case the XPC issue we've been seeing is due to a race between the app being opened, and Gatekeeper ingesting the notarization ticket, we'll also force Gatekeeper to read the ticket by running `spctl -a` on the app bundle, and the extension bundle. The latter always fails, but an attempt to read it can't hurt. 