### PR TITLE
fix: start coder connect on launch after SE is installed

### DIFF
--- a/Coder-Desktop/Coder-DesktopTests/LoginFormTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/LoginFormTests.swift
@@ -107,6 +107,12 @@ struct LoginTests {
             data: [.get: Client.encoder.encode(buildInfo)]
         ).register()
 
+        try Mock(
+            url: url.appendingPathComponent("/api/v2/users/me"),
+            statusCode: 200,
+            data: [.get: Client.encoder.encode(User(id: UUID(), username: "username"))]
+        ).register()
+
         try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
                 try view.find(ViewType.TextField.self).setInput(url.absoluteString)


### PR DESCRIPTION
This is a fix for #108. Previously we would start the VPN immediately on launch if the config option was true. This starting of the VPN raced with any concurrent upgrades of the network extension, causing the VPN to be started with a VPN config belonging to the older network extension, and producing a consistent error message: 
![image](https://github.com/user-attachments/assets/a69932cb-4c86-4d45-8ab5-5843e255f395)

Instead, we should only start the VPN once we know that the system extension and VPN configuration are installed.