### PR TITLE
chore: conditionally start file sync daemon

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -40,8 +40,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             vpn.startWhenReady = true
         }
         vpn.installSystemExtension()
+        #if arch(arm64)
+        let mutagenBinary = "mutagen-darwin-arm64"
+        #elseif arch(x86_64)
+        let mutagenBinary = "mutagen-darwin-amd64"
+        #endif
         fileSyncDaemon = MutagenDaemon(
-            mutagenPath: Bundle.main.url(forResource: "mutagen-darwin-arm64", withExtension: nil)
+            mutagenPath: Bundle.main.url(forResource: mutagenBinary, withExtension: nil)
         )
     }
 

--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -36,11 +36,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     override init() {
         vpn = CoderVPNService()
         state = AppState(onChange: vpn.configureTunnelProviderProtocol)
-        fileSyncDaemon = MutagenDaemon()
         if state.startVPNOnLaunch {
             vpn.startWhenReady = true
         }
         vpn.installSystemExtension()
+        fileSyncDaemon = MutagenDaemon(
+            mutagenPath: Bundle.main.url(forResource: "mutagen-darwin-arm64", withExtension: nil)
+        )
     }
 
     func applicationDidFinishLaunching(_: Notification) {
@@ -72,10 +74,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if await !vpn.loadNetworkExtensionConfig() {
                 state.reconfigure()
             }
-        }
-        // TODO: Start the daemon only once a file sync is configured
-        Task {
-            await fileSyncDaemon.start()
         }
     }
 

--- a/Coder-Desktop/project.yml
+++ b/Coder-Desktop/project.yml
@@ -116,7 +116,10 @@ packages:
     exactVersion: 1.24.2
   Subprocess:
     url: https://github.com/jamf/Subprocess
-    revision: 9d67b79 
+    revision: 9d67b79
+  Semaphore:
+    url: https://github.com/groue/Semaphore/
+    exactVersion: 0.1.0
 
 targets:
   Coder Desktop:
@@ -276,6 +279,7 @@ targets:
         product: SwiftProtobufPluginLibrary
       - package: GRPC
       - package: Subprocess
+      - package: Semaphore
       - target: CoderSDK
         embed: false
 


### PR DESCRIPTION
This makes a few improvements to #98:
- The mutagen path & data directory can be now be configured on the MutagenDaemon, to support overriding it in tests (coming soon).
- A mutagen daemon failure now kills the process, such that can it be restarted (TBC).
- Makes start & stop transitions mutually exclusive via a semaphore, to account for actor re-entrancy.
- The start operation now waits for the daemon to respond to a version request before completing.
- The daemon is always started on launch, but then immediately stopped if it doesn't manage any file sync sessions, as to not run in the background unncessarily.