### PR TITLE
feat: support restarting file sync sessions

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Preview Content/PreviewFileSync.swift
+++ b/Coder-Desktop/Coder-Desktop/Preview Content/PreviewFileSync.swift
@@ -27,4 +27,6 @@ final class PreviewFileSync: FileSyncDaemon {
     func pauseSessions(ids _: [String]) async throws(VPNLib.DaemonError) {}
 
     func resumeSessions(ids _: [String]) async throws(VPNLib.DaemonError) {}
+
+    func resetSessions(ids _: [String]) async throws(VPNLib.DaemonError) {}
 }

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncConfig.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncConfig.swift
@@ -89,7 +89,7 @@ struct FileSyncConfig<VPN: VPNService, FS: FileSyncDaemon>: View {
                 Text("""
                 File sync daemon failed. The daemon log file at\n\(fileSync.logFile.path)\nhas been opened.
                 """).onAppear {
-                    // Open the log file in the default editor
+                    // Opens the log file in Console
                     NSWorkspace.shared.open(fileSync.logFile)
                 }
             }.task {

--- a/Coder-Desktop/Coder-DesktopTests/Util.swift
+++ b/Coder-Desktop/Coder-DesktopTests/Util.swift
@@ -52,6 +52,8 @@ class MockFileSyncDaemon: FileSyncDaemon {
     func pauseSessions(ids _: [String]) async throws(VPNLib.DaemonError) {}
 
     func resumeSessions(ids _: [String]) async throws(VPNLib.DaemonError) {}
+
+    func resetSessions(ids _: [String]) async throws(VPNLib.DaemonError) {}
 }
 
 extension Inspection: @unchecked Sendable, @retroactive InspectionEmissary {}

--- a/Coder-Desktop/VPNLib/FileSync/FileSyncDaemon.swift
+++ b/Coder-Desktop/VPNLib/FileSync/FileSyncDaemon.swift
@@ -18,6 +18,7 @@ public protocol FileSyncDaemon: ObservableObject {
     func deleteSessions(ids: [String]) async throws(DaemonError)
     func pauseSessions(ids: [String]) async throws(DaemonError)
     func resumeSessions(ids: [String]) async throws(DaemonError)
+    func resetSessions(ids: [String]) async throws(DaemonError)
 }
 
 @MainActor


### PR DESCRIPTION
<img width="210" alt="image" src="https://github.com/user-attachments/assets/215ec4f1-c2a9-4e64-af8f-4aab0f2fa352" />

Equivalent to `mutagen sync restart`, such as for resolving safety checks: https://mutagen.io/documentation/introduction/getting-started/#resetting-sessions

Also adds an error alert for all fallible operations on the config window.