### PR TITLE
feat: add conflict descriptions and file sync context menu

### DIFF
--- a/Coder-Desktop/VPNLib/FileSync/MutagenConvert.swift
+++ b/Coder-Desktop/VPNLib/FileSync/MutagenConvert.swift
@@ -142,7 +142,7 @@ func formatChanges(_ changesByPath: [String: (alpha: [Core_Change], beta: [Core_
                changes.alpha[0].new.kind == .file,
                changes.beta[0].new.kind == .file
             {
-                result += "File: `\(formatPath(path))`\n"
+                result += "File: '\(formatPath(path))'\n"
                 continue
             }
             // Friendly message for `<non-existent -> !<non-existent>` conflicts
@@ -152,7 +152,7 @@ func formatChanges(_ changesByPath: [String: (alpha: [Core_Change], beta: [Core_
                changes.beta[0].hasNew
             {
                 result += """
-                An entry, `\(formatPath(path))`, was created on both endpoints that does not match.
+                An entry, '\(formatPath(path))', was created on both endpoints that does not match.
                 You can resolve this conflict by deleting one of the entries.\n
                 """
                 continue
@@ -160,7 +160,7 @@ func formatChanges(_ changesByPath: [String: (alpha: [Core_Change], beta: [Core_
         }
 
         let formattedPath = formatPath(path)
-        result += "Path: \(formattedPath)\n"
+        result += "Path: '\(formattedPath)'\n"
 
         // TODO: Local & Remote should be replaced with Alpha & Beta, once it's possible to configure which is which
 

--- a/Coder-Desktop/VPNLib/FileSync/MutagenConvert.swift
+++ b/Coder-Desktop/VPNLib/FileSync/MutagenConvert.swift
@@ -40,16 +40,28 @@ func accumulateErrors(from state: Synchronization_State) -> [FileSyncError] {
         errors.append(.generic(state.lastError))
     }
     for problem in state.alphaState.scanProblems {
-        errors.append(.problem(.local, .scan, path: problem.path, error: problem.error))
+        errors.append(.problem(.alpha, .scan, path: problem.path, error: problem.error))
     }
     for problem in state.alphaState.transitionProblems {
-        errors.append(.problem(.local, .transition, path: problem.path, error: problem.error))
+        errors.append(.problem(.alpha, .transition, path: problem.path, error: problem.error))
     }
     for problem in state.betaState.scanProblems {
-        errors.append(.problem(.remote, .scan, path: problem.path, error: problem.error))
+        errors.append(.problem(.beta, .scan, path: problem.path, error: problem.error))
     }
     for problem in state.betaState.transitionProblems {
-        errors.append(.problem(.remote, .transition, path: problem.path, error: problem.error))
+        errors.append(.problem(.beta, .transition, path: problem.path, error: problem.error))
+    }
+    if state.alphaState.excludedScanProblems > 0 {
+        errors.append(.excludedProblems(.alpha, .scan, state.alphaState.excludedScanProblems))
+    }
+    if state.alphaState.excludedTransitionProblems > 0 {
+        errors.append(.excludedProblems(.alpha, .transition, state.alphaState.excludedTransitionProblems))
+    }
+    if state.betaState.excludedScanProblems > 0 {
+        errors.append(.excludedProblems(.beta, .scan, state.betaState.excludedScanProblems))
+    }
+    if state.betaState.excludedTransitionProblems > 0 {
+        errors.append(.excludedProblems(.beta, .transition, state.betaState.excludedTransitionProblems))
     }
     return errors
 }
@@ -78,5 +90,125 @@ extension Prompting_HostResponse {
                 throw .invalidGrpcResponse("disallowed prompt message type")
             }
         }
+    }
+}
+
+// Translated from `cmd/mutagen/sync/list_monitor_common.go`
+func formatConflicts(conflicts: [Core_Conflict], excludedConflicts: UInt64) -> String {
+    var result = ""
+    for (i, conflict) in conflicts.enumerated() {
+        var changesByPath: [String: (alpha: [Core_Change], beta: [Core_Change])] = [:]
+
+        // Group alpha changes by path
+        for alphaChange in conflict.alphaChanges {
+            let path = alphaChange.path
+            if changesByPath[path] == nil {
+                changesByPath[path] = (alpha: [], beta: [])
+            }
+            changesByPath[path]!.alpha.append(alphaChange)
+        }
+
+        // Group beta changes by path
+        for betaChange in conflict.betaChanges {
+            let path = betaChange.path
+            if changesByPath[path] == nil {
+                changesByPath[path] = (alpha: [], beta: [])
+            }
+            changesByPath[path]!.beta.append(betaChange)
+        }
+
+        result += formatChanges(changesByPath)
+
+        if i < conflicts.count - 1 || excludedConflicts > 0 {
+            result += "\n"
+        }
+    }
+
+    if excludedConflicts > 0 {
+        result += "...+\(excludedConflicts) more conflicts...\n"
+    }
+
+    return result
+}
+
+func formatChanges(_ changesByPath: [String: (alpha: [Core_Change], beta: [Core_Change])]) -> String {
+    var result = ""
+
+    for (path, changes) in changesByPath {
+        if changes.alpha.count == 1, changes.beta.count == 1 {
+            // Simple message for basic file conflicts
+            if changes.alpha[0].hasNew,
+               changes.beta[0].hasNew,
+               changes.alpha[0].new.kind == .file,
+               changes.beta[0].new.kind == .file
+            {
+                result += "File: `\(formatPath(path))`\n"
+                continue
+            }
+            // Friendly message for `<non-existent -> !<non-existent>` conflicts
+            if !changes.alpha[0].hasOld,
+               !changes.beta[0].hasOld,
+               changes.alpha[0].hasNew,
+               changes.beta[0].hasNew
+            {
+                result += """
+                An entry, `\(formatPath(path))`, was created on both endpoints that does not match.
+                You can resolve this conflict by deleting one of the entries.\n
+                """
+                continue
+            }
+        }
+
+        let formattedPath = formatPath(path)
+        result += "Path: \(formattedPath)\n"
+
+        // TODO: Local & Remote should be replaced with Alpha & Beta, once it's possible to configure which is which
+
+        if !changes.alpha.isEmpty {
+            result += " Local changes:\n"
+            for change in changes.alpha {
+                let old = formatEntry(change.hasOld ? change.old : nil)
+                let new = formatEntry(change.hasNew ? change.new : nil)
+                result += "  \(old) → \(new)\n"
+            }
+        }
+
+        if !changes.beta.isEmpty {
+            result += " Remote changes:\n"
+            for change in changes.beta {
+                let old = formatEntry(change.hasOld ? change.old : nil)
+                let new = formatEntry(change.hasNew ? change.new : nil)
+                result += "  \(old) → \(new)\n"
+            }
+        }
+    }
+
+    return result
+}
+
+func formatPath(_ path: String) -> String {
+    path.isEmpty ? "<root>" : path
+}
+
+func formatEntry(_ entry: Core_Entry?) -> String {
+    guard let entry else {
+        return "<non-existent>"
+    }
+
+    switch entry.kind {
+    case .directory:
+        return "Directory"
+    case .file:
+        return entry.executable ? "Executable File" : "File"
+    case .symbolicLink:
+        return "Symbolic Link (\(entry.target))"
+    case .untracked:
+        return "Untracked content"
+    case .problematic:
+        return "Problematic content (\(entry.problem))"
+    case .UNRECOGNIZED:
+        return "<unknown>"
+    case .phantomDirectory:
+        return "Phantom Directory"
     }
 }


### PR DESCRIPTION
Last QoL PR for now..

This adds buttons to the alt click context menu:
<img width="971" alt="Screenshot 2025-03-28 at 3 25 12 pm" src="https://github.com/user-attachments/assets/2477ee7d-2466-4fa5-9f7f-53a711ffdd64" />



And it adds a brief description of each conflict to the status tooltip:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/e513faf1-414f-4612-902d-204b277a34b1" />

There's three cases for now. The first is just a basic file conflict, the second is if there's a type conflict (file, directory, symlink, etc), and the third is self-explanatory.

We'll need to come up with a proper design for how we show conflicts, so this implementation is just to not leave users in the dark if they run into any.