### PR TITLE
fix: improve file sync agent picker

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncConfig.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncConfig.swift
@@ -103,13 +103,6 @@ struct FileSyncConfig<VPN: VPNService, FS: FileSyncDaemon>: View {
                     // Opens the log file in Console
                     NSWorkspace.shared.open(fileSync.logFile)
                 }
-            }.task {
-                // When the Window is visible, poll for session updates every
-                // two seconds.
-                while !Task.isCancelled {
-                    await fileSync.refreshSessions()
-                    try? await Task.sleep(for: .seconds(2))
-                }
             }.onAppear {
                 isVisible = true
             }.onDisappear {

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncConfig.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncConfig.swift
@@ -107,9 +107,7 @@ struct FileSyncConfig<VPN: VPNService, FS: FileSyncDaemon>: View {
                 // When the Window is visible, poll for session updates every
                 // two seconds.
                 while !Task.isCancelled {
-                    if !fileSync.state.isFailed {
-                        await fileSync.refreshSessions()
-                    }
+                    await fileSync.refreshSessions()
                     try? await Task.sleep(for: .seconds(2))
                 }
             }.onAppear {

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
@@ -8,7 +8,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
     @EnvironmentObject private var fileSync: FS
 
     @State private var localPath: String = ""
-    @State private var remoteHostName: String?
+    @State private var remoteHostname: String?
     @State private var remotePath: String = ""
 
     @State private var loading: Bool = false
@@ -37,7 +37,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
                     }
                 }
                 Section {
-                    Picker("Workspace", selection: $remoteHostName) {
+                    Picker("Workspace", selection: $remoteHostname) {
                         ForEach(agents, id: \.id) { agent in
                             Text(agent.primaryHost!).tag(agent.primaryHost!)
                         }
@@ -55,16 +55,16 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
                 Button("Cancel", action: { dismiss() }).keyboardShortcut(.cancelAction)
                 Button(existingSession == nil ? "Add" : "Save") { Task { await submit() }}
                     .keyboardShortcut(.defaultAction)
-                    .disabled(localPath.isEmpty || remotePath.isEmpty || remoteHostName == nil)
+                    .disabled(localPath.isEmpty || remotePath.isEmpty || remoteHostname == nil)
             }.padding(20)
         }.onAppear {
             if let existingSession {
                 localPath = existingSession.alphaPath
-                remoteHostName = agents.first { $0.primaryHost == existingSession.agentHost }?.primaryHost
+                remoteHostname = agents.first { $0.primaryHost == existingSession.agentHost }?.primaryHost
                 remotePath = existingSession.betaPath
             } else {
                 // Set the picker to the first agent by default
-                remoteHostName = agents.first?.primaryHost
+                remoteHostname = agents.first?.primaryHost
             }
         }.disabled(loading)
             .alert("Error", isPresented: Binding(
@@ -77,7 +77,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
 
     func submit() async {
         createError = nil
-        guard let remoteHostName else {
+        guard let remoteHostname else {
             return
         }
         loading = true
@@ -88,7 +88,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
             }
             try await fileSync.createSession(
                 localPath: localPath,
-                agentHost: remoteHostName,
+                agentHost: remoteHostname,
                 remotePath: remotePath
             )
         } catch {

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
@@ -8,7 +8,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
     @EnvironmentObject private var fileSync: FS
 
     @State private var localPath: String = ""
-    @State private var chosenAgent: String?
+    @State private var remoteHostName: String?
     @State private var remotePath: String = ""
 
     @State private var loading: Bool = false
@@ -37,7 +37,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
                     }
                 }
                 Section {
-                    Picker("Workspace", selection: $chosenAgent) {
+                    Picker("Workspace", selection: $remoteHostName) {
                         ForEach(agents, id: \.id) { agent in
                             Text(agent.primaryHost!).tag(agent.primaryHost!)
                         }
@@ -55,16 +55,16 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
                 Button("Cancel", action: { dismiss() }).keyboardShortcut(.cancelAction)
                 Button(existingSession == nil ? "Add" : "Save") { Task { await submit() }}
                     .keyboardShortcut(.defaultAction)
-                    .disabled(localPath.isEmpty || remotePath.isEmpty || chosenAgent == nil)
+                    .disabled(localPath.isEmpty || remotePath.isEmpty || remoteHostName == nil)
             }.padding(20)
         }.onAppear {
             if let existingSession {
                 localPath = existingSession.alphaPath
-                chosenAgent = agents.first { $0.primaryHost == existingSession.agentHost }?.primaryHost
+                remoteHostName = agents.first { $0.primaryHost == existingSession.agentHost }?.primaryHost
                 remotePath = existingSession.betaPath
             } else {
                 // Set the picker to the first agent by default
-                chosenAgent = agents.first?.primaryHost
+                remoteHostName = agents.first?.primaryHost
             }
         }.disabled(loading)
             .alert("Error", isPresented: Binding(
@@ -77,7 +77,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
 
     func submit() async {
         createError = nil
-        guard let chosenAgent else {
+        guard let remoteHostName else {
             return
         }
         loading = true
@@ -88,7 +88,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
             }
             try await fileSync.createSession(
                 localPath: localPath,
-                agentHost: chosenAgent,
+                agentHost: remoteHostName,
                 remotePath: remotePath
             )
         } catch {

--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
@@ -116,6 +116,15 @@ struct VPNMenu<VPN: VPNService, FS: FileSyncDaemon>: View {
             .environmentObject(vpn)
             .environmentObject(state)
             .onReceive(inspection.notice) { inspection.visit(self, $0) } // ViewInspector
+            .task {
+                // If there's a file sync session error, an icon will be displayed
+                // next to the file sync button. The file sync window polls more
+                // frequently when it's open.
+                while !Task.isCancelled {
+                    await fileSync.refreshSessions()
+                    try? await Task.sleep(for: .seconds(15))
+                }
+            }
     }
 
     private var vpnDisabled: Bool {

--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
@@ -117,12 +117,9 @@ struct VPNMenu<VPN: VPNService, FS: FileSyncDaemon>: View {
             .environmentObject(state)
             .onReceive(inspection.notice) { inspection.visit(self, $0) } // ViewInspector
             .task {
-                // If there's a file sync session error, an icon will be displayed
-                // next to the file sync button. The file sync window polls more
-                // frequently when it's open.
                 while !Task.isCancelled {
                     await fileSync.refreshSessions()
-                    try? await Task.sleep(for: .seconds(15))
+                    try? await Task.sleep(for: .seconds(2))
                 }
             }
     }


### PR DESCRIPTION
Previously, the agent/workspace picker when creating a file sync session had the user choose between instances of the `Agent` struct. This meant the value would get unselected were the status of the agent to change. I'm not sure why I had the picker select the entire struct instead of just the hostname.