### PR TITLE
chore: add file sync daemon tests

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -51,9 +51,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         #elseif arch(x86_64)
             let mutagenBinary = "mutagen-darwin-amd64"
         #endif
-        fileSyncDaemon = MutagenDaemon(
+        let fileSyncDaemon = MutagenDaemon(
             mutagenPath: Bundle.main.url(forResource: mutagenBinary, withExtension: nil)
         )
+        Task {
+            await fileSyncDaemon.tryStart()
+        }
+        self.fileSyncDaemon = fileSyncDaemon
     }
 
     func applicationDidFinishLaunching(_: Notification) {

--- a/Coder-Desktop/Coder-Desktop/Preview Content/PreviewFileSync.swift
+++ b/Coder-Desktop/Coder-Desktop/Preview Content/PreviewFileSync.swift
@@ -20,7 +20,7 @@ final class PreviewFileSync: FileSyncDaemon {
         state = .stopped
     }
 
-    func createSession(localPath _: String, agentHost _: String, remotePath _: String) async throws(DaemonError) {}
+    func createSession(arg _: CreateSyncSessionRequest) async throws(DaemonError) {}
 
     func deleteSessions(ids _: [String]) async throws(VPNLib.DaemonError) {}
 

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncConfig.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncConfig.swift
@@ -166,10 +166,6 @@ struct FileSyncConfig<VPN: VPNService, FS: FileSyncDaemon>: View {
         defer { loading = false }
         do throws(DaemonError) {
             try await fileSync.deleteSessions(ids: [selection!])
-            if fileSync.sessionState.isEmpty {
-                // Last session was deleted, stop the daemon
-                await fileSync.stop()
-            }
         } catch {
             actionError = error
         }

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
@@ -102,7 +102,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
             try await fileSync.createSession(
                 arg: .init(
                     alpha: .init(path: localPath, protocolKind: .local),
-                    beta: .init(path: remotePath, protocolKind: .ssh(host: workspace.primaryHost!))
+                    beta: .init(path: remotePath, protocolKind: .ssh(host: remotePath))
                 )
             )
         } catch {

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
@@ -100,9 +100,10 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
                 try await fileSync.deleteSessions(ids: [existingSession.id])
             }
             try await fileSync.createSession(
-                localPath: localPath,
-                agentHost: remoteHostname,
-                remotePath: remotePath
+                arg: .init(
+                    alpha: .init(path: localPath, protocolKind: .local),
+                    beta: .init(path: remotePath, protocolKind: .ssh(host: workspace.primaryHost!))
+                )
             )
         } catch {
             createError = error

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FileSyncSessionModal.swift
@@ -102,7 +102,7 @@ struct FileSyncSessionModal<VPN: VPNService, FS: FileSyncDaemon>: View {
             try await fileSync.createSession(
                 arg: .init(
                     alpha: .init(path: localPath, protocolKind: .local),
-                    beta: .init(path: remotePath, protocolKind: .ssh(host: remotePath))
+                    beta: .init(path: remotePath, protocolKind: .ssh(host: remoteHostname))
                 )
             )
         } catch {

--- a/Coder-Desktop/Coder-DesktopTests/FilePickerTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/FilePickerTests.swift
@@ -103,8 +103,8 @@ struct FilePickerTests {
                 try disclosureGroup.expand()
 
                 // Disclosure group should expand out to 3 more directories
-                try #expect(await eventually { @MainActor in
-                    return try view.findAll(ViewType.DisclosureGroup.self).count == 6
+                #expect(await eventually { @MainActor in
+                    return view.findAll(ViewType.DisclosureGroup.self).count == 6
                 })
             }
         }

--- a/Coder-Desktop/Coder-DesktopTests/FileSyncDaemonTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/FileSyncDaemonTests.swift
@@ -16,6 +16,7 @@ class FileSyncDaemonTests {
     let mutagenAlphaDirectory: URL
     let mutagenBetaDirectory: URL
 
+    // Before each test
     init() throws {
         tempDir = FileManager.default.makeTempDir()!
         #if arch(arm64)
@@ -31,6 +32,7 @@ class FileSyncDaemonTests {
         try FileManager.default.createDirectory(at: mutagenBetaDirectory, withIntermediateDirectories: true)
     }
 
+    // After each test
     deinit {
         try? FileManager.default.removeItem(at: tempDir)
     }

--- a/Coder-Desktop/Coder-DesktopTests/FileSyncDaemonTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/FileSyncDaemonTests.swift
@@ -1,0 +1,165 @@
+@testable import Coder_Desktop
+import Foundation
+import GRPC
+import NIO
+import Subprocess
+import Testing
+import VPNLib
+import XCTest
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+class FileSyncDaemonTests {
+    let tempDir: URL
+    let mutagenBinary: URL
+    let mutagenDataDirectory: URL
+    let mutagenAlphaDirectory: URL
+    let mutagenBetaDirectory: URL
+
+    init() throws {
+        tempDir = FileManager.default.makeTempDir()!
+        #if arch(arm64)
+            let binaryName = "mutagen-darwin-arm64"
+        #elseif arch(x86_64)
+            let binaryName = "mutagen-darwin-amd64"
+        #endif
+        mutagenBinary = Bundle.main.url(forResource: binaryName, withExtension: nil)!
+        mutagenDataDirectory = tempDir.appending(path: "mutagen")
+        mutagenAlphaDirectory = tempDir.appending(path: "alpha")
+        try FileManager.default.createDirectory(at: mutagenAlphaDirectory, withIntermediateDirectories: true)
+        mutagenBetaDirectory = tempDir.appending(path: "beta")
+        try FileManager.default.createDirectory(at: mutagenBetaDirectory, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func statesEqual(_ first: DaemonState, _ second: DaemonState) -> Bool {
+        switch (first, second) {
+        case (.stopped, .stopped):
+            true
+        case (.running, .running):
+            true
+        case (.unavailable, .unavailable):
+            true
+        default:
+            false
+        }
+    }
+
+    @Test
+    func fullSync() async throws {
+        let daemon = MutagenDaemon(mutagenPath: mutagenBinary, mutagenDataDirectory: mutagenDataDirectory)
+        #expect(statesEqual(daemon.state, .stopped))
+        #expect(daemon.sessionState.count == 0)
+
+        // The daemon won't start until we create a session
+        await daemon.tryStart()
+        #expect(statesEqual(daemon.state, .stopped))
+        #expect(daemon.sessionState.count == 0)
+
+        try await daemon.createSession(
+            arg: .init(
+                alpha: .init(
+                    path: mutagenAlphaDirectory.path(),
+                    protocolKind: .local
+                ),
+                beta: .init(
+                    path: mutagenBetaDirectory.path(),
+                    protocolKind: .local
+                )
+            )
+        )
+
+        // Daemon should have started itself
+        #expect(statesEqual(daemon.state, .running))
+        #expect(daemon.sessionState.count == 1)
+
+        // Write a file to Alpha
+        let alphaFile = mutagenAlphaDirectory.appendingPathComponent("test.txt")
+        try "Hello, World!".write(to: alphaFile, atomically: true, encoding: .utf8)
+        try #expect(
+            await eventually(timeout: .seconds(5), interval: .milliseconds(100)) { @MainActor in
+                return try FileManager.default.fileExists(
+                    atPath: self.mutagenBetaDirectory.appending(path: "test.txt").path()
+                )
+            })
+
+        try await daemon.deleteSessions(ids: daemon.sessionState.map(\.id))
+        #expect(daemon.sessionState.count == 0)
+        // Daemon should have stopped itself once all sessions are deleted
+        #expect(statesEqual(daemon.state, .stopped))
+    }
+
+    @Test
+    func autoStopStart() async throws {
+        let daemon = MutagenDaemon(mutagenPath: mutagenBinary, mutagenDataDirectory: mutagenDataDirectory)
+        #expect(statesEqual(daemon.state, .stopped))
+        #expect(daemon.sessionState.count == 0)
+
+        try await daemon.createSession(
+            arg: .init(
+                alpha: .init(
+                    path: mutagenAlphaDirectory.path(),
+                    protocolKind: .local
+                ),
+                beta: .init(
+                    path: mutagenBetaDirectory.path(),
+                    protocolKind: .local
+                )
+            )
+        )
+
+        try await daemon.createSession(
+            arg: .init(
+                alpha: .init(
+                    path: mutagenAlphaDirectory.path(),
+                    protocolKind: .local
+                ),
+                beta: .init(
+                    path: mutagenBetaDirectory.path(),
+                    protocolKind: .local
+                )
+            )
+        )
+
+        #expect(statesEqual(daemon.state, .running))
+        #expect(daemon.sessionState.count == 2)
+
+        try await daemon.deleteSessions(ids: [daemon.sessionState[0].id])
+        #expect(daemon.sessionState.count == 1)
+        #expect(statesEqual(daemon.state, .running))
+
+        try await daemon.deleteSessions(ids: [daemon.sessionState[0].id])
+        #expect(daemon.sessionState.count == 0)
+        #expect(statesEqual(daemon.state, .stopped))
+    }
+
+    @Test
+    func orphaned() async throws {
+        let daemon1 = MutagenDaemon(mutagenPath: mutagenBinary, mutagenDataDirectory: mutagenDataDirectory)
+        await daemon1.refreshSessions()
+        try await daemon1.createSession(arg:
+            .init(
+                alpha: .init(
+                    path: mutagenAlphaDirectory.path(),
+                    protocolKind: .local
+                ),
+                beta: .init(
+                    path: mutagenBetaDirectory.path(),
+                    protocolKind: .local
+                )
+            )
+        )
+        #expect(statesEqual(daemon1.state, .running))
+        #expect(daemon1.sessionState.count == 1)
+
+        let daemon2 = MutagenDaemon(mutagenPath: mutagenBinary, mutagenDataDirectory: mutagenDataDirectory)
+        await daemon2.tryStart()
+        #expect(statesEqual(daemon2.state, .running))
+
+        // Daemon 2 should have killed daemon 1, causing it to fail
+        #expect(daemon1.state.isFailed)
+    }
+}

--- a/Coder-Desktop/Coder-DesktopTests/FileSyncDaemonTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/FileSyncDaemonTests.swift
@@ -81,9 +81,9 @@ class FileSyncDaemonTests {
         // Write a file to Alpha
         let alphaFile = mutagenAlphaDirectory.appendingPathComponent("test.txt")
         try "Hello, World!".write(to: alphaFile, atomically: true, encoding: .utf8)
-        try #expect(
+        #expect(
             await eventually(timeout: .seconds(5), interval: .milliseconds(100)) { @MainActor in
-                return try FileManager.default.fileExists(
+                return FileManager.default.fileExists(
                     atPath: self.mutagenBetaDirectory.appending(path: "test.txt").path()
                 )
             })

--- a/Coder-Desktop/Coder-DesktopTests/Util.swift
+++ b/Coder-Desktop/Coder-DesktopTests/Util.swift
@@ -47,7 +47,7 @@ class MockFileSyncDaemon: FileSyncDaemon {
         []
     }
 
-    func createSession(localPath _: String, agentHost _: String, remotePath _: String) async throws(DaemonError) {}
+    func createSession(arg _: CreateSyncSessionRequest) async throws(DaemonError) {}
 
     func pauseSessions(ids _: [String]) async throws(VPNLib.DaemonError) {}
 
@@ -81,4 +81,19 @@ public func eventually(
         throw lastError
     }
     return false
+}
+
+extension FileManager {
+    func makeTempDir() -> URL? {
+        let tempDirectory = FileManager.default.temporaryDirectory
+        let directoryName = String(Int.random(in: 0 ..< 1_000_000))
+        let directoryURL = tempDirectory.appendingPathComponent(directoryName)
+
+        do {
+            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            return directoryURL
+        } catch {
+            return nil
+        }
+    }
 }

--- a/Coder-Desktop/VPNLib/FileSync/FileSyncManagement.swift
+++ b/Coder-Desktop/VPNLib/FileSync/FileSyncManagement.swift
@@ -33,8 +33,12 @@ public extension MutagenDaemon {
             req.specification = .with { spec in
                 spec.alpha = arg.alpha.mutagenURL
                 spec.beta = arg.beta.mutagenURL
-                // TODO: Ingest a config from somewhere
-                spec.configuration = Synchronization_Configuration()
+                // TODO: Ingest configs from somewhere
+                spec.configuration = .with {
+                    // ALWAYS ignore VCS directories for now
+                    // https://mutagen.io/documentation/synchronization/version-control-systems/
+                    $0.ignoreVcsmode = .ignore
+                }
                 spec.configurationAlpha = Synchronization_Configuration()
                 spec.configurationBeta = Synchronization_Configuration()
             }

--- a/Coder-Desktop/project.yml
+++ b/Coder-Desktop/project.yml
@@ -164,7 +164,7 @@ targets:
         SKIP_INSTALL: NO
         LD_RUNPATH_SEARCH_PATHS:
           # Load frameworks from the SE bundle.
-          - "@executable_path/../../Contents/Library/SystemExtensions/com.coder.Coder-Desktop.VPN.systemextension/Contents/Frameworks" 
+          - "@executable_path/../../Contents/Library/SystemExtensions/com.coder.Coder-Desktop.VPN.systemextension/Contents/Frameworks"
           - "@executable_path/../Frameworks"
           - "@loader_path/Frameworks"
     dependencies:
@@ -192,6 +192,8 @@ targets:
     platform: macOS
     sources:
       - path: Coder-DesktopTests
+      - path: Resources
+        buildPhase: resources
     settings:
       base:
         BUNDLE_LOADER: "$(TEST_HOST)"

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ test: $(addprefix $(PROJECT)/Resources/,$(MUTAGEN_RESOURCES)) $(XCPROJECT) ## Ru
 		-testPlan $(TEST_PLAN) \
 		-skipPackagePluginValidation \
 		CODE_SIGNING_REQUIRED=NO \
-		CODE_SIGNING_ALLOWED=NO
+		CODE_SIGNING_ALLOWED=NO | xcbeautify
 
 .PHONY: lint
 lint: lint/swift lint/actions ## Lint all files in the repo

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ fmt: ## Run Swift file formatter
 		$(FMTFLAGS) .
 
 .PHONY: test
-test: $(XCPROJECT) ## Run all tests
+test: $(XCPROJECT) $(addprefix $(PROJECT)/Resources/,$(MUTAGEN_RESOURCES)) ## Run all tests
 	set -o pipefail && xcodebuild test \
 		-project $(XCPROJECT) \
 		-scheme $(SCHEME) \

--- a/Makefile
+++ b/Makefile
@@ -116,14 +116,14 @@ fmt: ## Run Swift file formatter
 		$(FMTFLAGS) .
 
 .PHONY: test
-test: $(XCPROJECT) $(addprefix $(PROJECT)/Resources/,$(MUTAGEN_RESOURCES)) ## Run all tests
+test: $(addprefix $(PROJECT)/Resources/,$(MUTAGEN_RESOURCES)) $(XCPROJECT) ## Run all tests
 	set -o pipefail && xcodebuild test \
 		-project $(XCPROJECT) \
 		-scheme $(SCHEME) \
 		-testPlan $(TEST_PLAN) \
 		-skipPackagePluginValidation \
 		CODE_SIGNING_REQUIRED=NO \
-		CODE_SIGNING_ALLOWED=NO | xcbeautify
+		CODE_SIGNING_ALLOWED=NO
 
 .PHONY: lint
 lint: lint/swift lint/actions ## Lint all files in the repo


### PR DESCRIPTION
These are just regression tests for the core file sync daemon functionality.

Also has sync sessions ignore VCS directories by default, as per the file sync RFC.