### PR TITLE
refactor(CoderSDK): share code between Client and AgentClient

### DIFF
--- a/Coder-Desktop/Coder-Desktop/State.swift
+++ b/Coder-Desktop/Coder-Desktop/State.swift
@@ -122,7 +122,7 @@ class AppState: ObservableObject {
             let client = Client(url: baseAccessURL!, token: sessionToken!)
             do {
                 _ = try await client.user("me")
-            } catch let ClientError.api(apiErr) {
+            } catch let SDKError.api(apiErr) {
                 // Expired token
                 if apiErr.statusCode == 401 {
                     clearSession()

--- a/Coder-Desktop/Coder-Desktop/Views/FileSync/FilePicker.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/FileSync/FilePicker.swift
@@ -72,7 +72,7 @@ struct FilePicker: View {
 class FilePickerModel: ObservableObject {
     @Published var rootEntries: [FilePickerEntryModel] = []
     @Published var rootIsLoading: Bool = false
-    @Published var error: ClientError?
+    @Published var error: SDKError?
 
     // It's important that `AgentClient` is a reference type (class)
     // as we were having performance issues with a struct (unless it was a binding).
@@ -87,7 +87,7 @@ class FilePickerModel: ObservableObject {
         rootIsLoading = true
         Task {
             defer { rootIsLoading = false }
-            do throws(ClientError) {
+            do throws(SDKError) {
                 rootEntries = try await client
                     .listAgentDirectory(.init(path: [], relativity: .root))
                     .toModels(client: client)
@@ -149,7 +149,7 @@ class FilePickerEntryModel: Identifiable, Hashable, ObservableObject {
 
     @Published var entries: [FilePickerEntryModel]?
     @Published var isLoading = false
-    @Published var error: ClientError?
+    @Published var error: SDKError?
     @Published private var innerIsExpanded = false
     var isExpanded: Bool {
         get { innerIsExpanded }
@@ -193,7 +193,7 @@ class FilePickerEntryModel: Identifiable, Hashable, ObservableObject {
                     innerIsExpanded = true
                 }
             }
-            do throws(ClientError) {
+            do throws(SDKError) {
                 entries = try await client
                     .listAgentDirectory(.init(path: path, relativity: .root))
                     .toModels(client: client)

--- a/Coder-Desktop/Coder-Desktop/Views/LoginForm.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/LoginForm.swift
@@ -207,7 +207,7 @@ enum LoginError: Error {
     case invalidURL
     case outdatedCoderVersion
     case missingServerVersion
-    case failedAuth(ClientError)
+    case failedAuth(SDKError)
 
     var description: String {
         switch self {

--- a/Coder-Desktop/Coder-DesktopTests/FilePickerTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/FilePickerTests.swift
@@ -60,7 +60,7 @@ struct FilePickerTests {
         try Mock(
             url: url.appendingPathComponent("/api/v0/list-directory"),
             statusCode: 200,
-            data: [.post: Client.encoder.encode(mockResponse)]
+            data: [.post: CoderSDK.encoder.encode(mockResponse)]
         ).register()
 
         try await ViewHosting.host(view) {
@@ -88,7 +88,7 @@ struct FilePickerTests {
         try Mock(
             url: url.appendingPathComponent("/api/v0/list-directory"),
             statusCode: 200,
-            data: [.post: Client.encoder.encode(mockResponse)]
+            data: [.post: CoderSDK.encoder.encode(mockResponse)]
         ).register()
 
         try await ViewHosting.host(view) {

--- a/Coder-Desktop/Coder-DesktopTests/LoginFormTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/LoginFormTests.swift
@@ -79,7 +79,7 @@ struct LoginTests {
         try Mock(
             url: url.appendingPathComponent("/api/v2/buildinfo"),
             statusCode: 200,
-            data: [.get: Client.encoder.encode(buildInfo)]
+            data: [.get: CoderSDK.encoder.encode(buildInfo)]
         ).register()
         Mock(url: url.appendingPathComponent("/api/v2/users/me"), statusCode: 401, data: [.get: Data()]).register()
 
@@ -104,13 +104,13 @@ struct LoginTests {
         try Mock(
             url: url.appendingPathComponent("/api/v2/buildinfo"),
             statusCode: 200,
-            data: [.get: Client.encoder.encode(buildInfo)]
+            data: [.get: CoderSDK.encoder.encode(buildInfo)]
         ).register()
 
         try Mock(
             url: url.appendingPathComponent("/api/v2/users/me"),
             statusCode: 200,
-            data: [.get: Client.encoder.encode(User(id: UUID(), username: "username"))]
+            data: [.get: CoderSDK.encoder.encode(User(id: UUID(), username: "username"))]
         ).register()
 
         try await ViewHosting.host(view) {
@@ -140,13 +140,13 @@ struct LoginTests {
         try Mock(
             url: url.appendingPathComponent("/api/v2/users/me"),
             statusCode: 200,
-            data: [.get: Client.encoder.encode(user)]
+            data: [.get: CoderSDK.encoder.encode(user)]
         ).register()
 
         try Mock(
             url: url.appendingPathComponent("/api/v2/buildinfo"),
             statusCode: 200,
-            data: [.get: Client.encoder.encode(buildInfo)]
+            data: [.get: CoderSDK.encoder.encode(buildInfo)]
         ).register()
 
         try await ViewHosting.host(view) {

--- a/Coder-Desktop/CoderSDK/AgentClient.swift
+++ b/Coder-Desktop/CoderSDK/AgentClient.swift
@@ -1,7 +1,22 @@
 public final class AgentClient: Sendable {
-    let client: Client
+    let agentURL: URL
 
     public init(agentHost: String) {
-        client = Client(url: URL(string: "http://\(agentHost):4")!)
+        agentURL = URL(string: "http://\(agentHost):4")!
+    }
+
+    func request(
+        _ path: String,
+        method: HTTPMethod
+    ) async throws(SDKError) -> HTTPResponse {
+        try await CoderSDK.request(baseURL: agentURL, path: path, method: method)
+    }
+
+    func request(
+        _ path: String,
+        method: HTTPMethod,
+        body: some Encodable & Sendable
+    ) async throws(SDKError) -> HTTPResponse {
+        try await CoderSDK.request(baseURL: agentURL, path: path, method: method, body: body)
     }
 }

--- a/Coder-Desktop/CoderSDK/AgentLS.swift
+++ b/Coder-Desktop/CoderSDK/AgentLS.swift
@@ -1,10 +1,10 @@
 public extension AgentClient {
-    func listAgentDirectory(_ req: LSRequest) async throws(ClientError) -> LSResponse {
-        let res = try await client.request("/api/v0/list-directory", method: .post, body: req)
+    func listAgentDirectory(_ req: LSRequest) async throws(SDKError) -> LSResponse {
+        let res = try await request("/api/v0/list-directory", method: .post, body: req)
         guard res.resp.statusCode == 200 else {
-            throw client.responseAsError(res)
+            throw responseAsError(res)
         }
-        return try client.decode(LSResponse.self, from: res.data)
+        return try decode(LSResponse.self, from: res.data)
     }
 }
 

--- a/Coder-Desktop/CoderSDK/Deployment.swift
+++ b/Coder-Desktop/CoderSDK/Deployment.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension Client {
-    func buildInfo() async throws(ClientError) -> BuildInfoResponse {
+    func buildInfo() async throws(SDKError) -> BuildInfoResponse {
         let res = try await request("/api/v2/buildinfo", method: .get)
         guard res.resp.statusCode == 200 else {
             throw responseAsError(res)

--- a/Coder-Desktop/CoderSDK/User.swift
+++ b/Coder-Desktop/CoderSDK/User.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension Client {
-    func user(_ ident: String) async throws(ClientError) -> User {
+    func user(_ ident: String) async throws(SDKError) -> User {
         let res = try await request("/api/v2/users/\(ident)", method: .get)
         guard res.resp.statusCode == 200 else {
             throw responseAsError(res)

--- a/Coder-Desktop/CoderSDKTests/CoderSDKTests.swift
+++ b/Coder-Desktop/CoderSDKTests/CoderSDKTests.swift
@@ -19,7 +19,7 @@ struct CoderSDKTests {
             url: url.appending(path: "api/v2/users/johndoe"),
             contentType: .json,
             statusCode: 200,
-            data: [.get: Client.encoder.encode(user)]
+            data: [.get: CoderSDK.encoder.encode(user)]
         )
         var correctHeaders = false
         mock.onRequestHandler = OnRequestHandler { req in
@@ -45,7 +45,7 @@ struct CoderSDKTests {
             url: url.appending(path: "api/v2/buildinfo"),
             contentType: .json,
             statusCode: 200,
-            data: [.get: Client.encoder.encode(buildInfo)]
+            data: [.get: CoderSDK.encoder.encode(buildInfo)]
         ).register()
 
         let retBuildInfo = try await client.buildInfo()


### PR DESCRIPTION
Refactor to address review feedback that `AgentClient` extending the regular `Client` was confusing.