### PR TITLE
fix: support old VPN config names in post & pre install scripts

### DIFF
--- a/pkgbuild/scripts/postinstall
+++ b/pkgbuild/scripts/postinstall
@@ -6,9 +6,9 @@ VPN_MARKER_FILE="/tmp/coder_vpn_was_running"
 # Before this script, or the user, opens the app, make sure
 # Gatekeeper has ingested the notarization ticket.
 spctl -avvv "/Applications/Coder Desktop.app"
-# spctl can't assess non-apps, so this will always return a non-zero exit code, 
-# but the error message implies at minimum the signature of the extension was 
-# checked. 
+# spctl can't assess non-apps, so this will always return a non-zero exit code,
+# but the error message implies at minimum the signature of the extension was
+# checked.
 spctl -avvv "/Applications/Coder Desktop.app/Contents/Library/SystemExtensions/com.coder.Coder-Desktop.VPN.systemextension" || true
 
 # Restart Coder Desktop if it was running before
@@ -24,7 +24,7 @@ if [ -f "$VPN_MARKER_FILE" ]; then
   echo "Restarting CoderVPN..."
   echo "Sleeping for 3..."
   sleep 3
-  scutil --nc start "Coder"
+  scutil --nc start "$(scutil --nc list | grep "com.coder.Coder-Desktop" | awk -F'"' '{print $2}')"
   rm "$VPN_MARKER_FILE"
   echo "CoderVPN started."
 fi

--- a/pkgbuild/scripts/preinstall
+++ b/pkgbuild/scripts/preinstall
@@ -9,22 +9,22 @@ if pgrep 'Coder Desktop'; then
   touch $RUNNING_MARKER_FILE
 fi
 
-vpnName=$(scutil --nc list | grep "com.coder.Coder-Desktop" | awk -F'"' '{print $2}')
+vpn_name=$(scutil --nc list | grep "com.coder.Coder-Desktop" | awk -F'"' '{print $2}')
 
 echo "Turning off VPN"
-if [[ -n "$vpnName" ]]; then
+if [[ -n "$vpn_name" ]]; then
   echo "CoderVPN found. Stopping..."
-  if scutil --nc status "$vpnName" | grep -q "^Connected$"; then
+  if scutil --nc status "$vpn_name" | grep -q "^Connected$"; then
     touch $VPN_MARKER_FILE
   fi
-  scutil --nc stop "$vpnName"
+  scutil --nc stop "$vpn_name"
 
   # Wait for VPN to be disconnected
-  while scutil --nc status "$vpnName" | grep -q "^Connected$"; do
+  while scutil --nc status "$vpn_name" | grep -q "^Connected$"; do
     echo "Waiting for VPN to disconnect..."
     sleep 1
   done
-  while scutil --nc status "$vpnName" | grep -q "^Disconnecting$"; do
+  while scutil --nc status "$vpn_name" | grep -q "^Disconnecting$"; do
     echo "Waiting for VPN to complete disconnect..."
     sleep 1
   done

--- a/pkgbuild/scripts/preinstall
+++ b/pkgbuild/scripts/preinstall
@@ -9,20 +9,22 @@ if pgrep 'Coder Desktop'; then
   touch $RUNNING_MARKER_FILE
 fi
 
+vpnName=$(scutil --nc list | grep "com.coder.Coder-Desktop" | awk -F'"' '{print $2}')
+
 echo "Turning off VPN"
-if scutil --nc list | grep -q "Coder"; then
+if [[ -n "$vpnName" ]]; then
   echo "CoderVPN found. Stopping..."
-  if scutil --nc status "Coder" | grep -q "^Connected$"; then
+  if scutil --nc status "$vpnName" | grep -q "^Connected$"; then
     touch $VPN_MARKER_FILE
   fi
-  scutil --nc stop "Coder"
+  scutil --nc stop "$vpnName"
 
   # Wait for VPN to be disconnected
-  while scutil --nc status "Coder" | grep -q "^Connected$"; do
+  while scutil --nc status "$vpnName" | grep -q "^Connected$"; do
     echo "Waiting for VPN to disconnect..."
     sleep 1
   done
-  while scutil --nc status "Coder" | grep -q "^Disconnecting$"; do
+  while scutil --nc status "$vpnName" | grep -q "^Disconnecting$"; do
     echo "Waiting for VPN to complete disconnect..."
     sleep 1
   done


### PR DESCRIPTION
One thing I noticed as part of my work on #121 is that our attempted fix introduced in #92 wasn't working as expected if the user had a VPN configuration installed before #86. 

This PR fetches the unique name of the VPN service dynamically, as part of the script, such that the service is started and stopped regardless of whether the service is called "Coder" or the older "CoderVPN".

This also ensures we don't break it again if we ever change that name, such as to "Coder Connect" (I don't totally recall why it was set to "Coder", but I don't mind it)