### PR TITLE
fix(pkgbuild): dont start coder connect after upgrade

### DIFF
--- a/pkgbuild/scripts/postinstall
+++ b/pkgbuild/scripts/postinstall
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 RUNNING_MARKER_FILE="/tmp/coder_desktop_running"
-VPN_MARKER_FILE="/tmp/coder_vpn_was_running"
 
 # Before this script, or the user, opens the app, make sure
 # Gatekeeper has ingested the notarization ticket.
@@ -17,16 +16,6 @@ if [ -f "$RUNNING_MARKER_FILE" ]; then
   open -a "Coder Desktop"
   rm "$RUNNING_MARKER_FILE"
   echo "Coder Desktop started."
-fi
-
-# Restart VPN if it was running before
-if [ -f "$VPN_MARKER_FILE" ]; then
-  echo "Restarting CoderVPN..."
-  echo "Sleeping for 3..."
-  sleep 3
-  scutil --nc start "$(scutil --nc list | grep "com.coder.Coder-Desktop" | awk -F'"' '{print $2}')"
-  rm "$VPN_MARKER_FILE"
-  echo "CoderVPN started."
 fi
 
 exit 0

--- a/pkgbuild/scripts/preinstall
+++ b/pkgbuild/scripts/preinstall
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 RUNNING_MARKER_FILE="/tmp/coder_desktop_running"
-VPN_MARKER_FILE="/tmp/coder_vpn_was_running"
 
-rm $VPN_MARKER_FILE $RUNNING_MARKER_FILE || true
+rm $RUNNING_MARKER_FILE || true
 
 if pgrep 'Coder Desktop'; then
   touch $RUNNING_MARKER_FILE
@@ -14,9 +13,6 @@ vpn_name=$(scutil --nc list | grep "com.coder.Coder-Desktop" | awk -F'"' '{print
 echo "Turning off VPN"
 if [[ -n "$vpn_name" ]]; then
   echo "CoderVPN found. Stopping..."
-  if scutil --nc status "$vpn_name" | grep -q "^Connected$"; then
-    touch $VPN_MARKER_FILE
-  fi
   scutil --nc stop "$vpn_name"
 
   # Wait for VPN to be disconnected


### PR DESCRIPTION
As part of my work on #121 and trying to reproduce the behaviour in a VM, I discovered the issue consistently occurs if the VPN is running when the app is launched (as the network extension is replaced on upgrade).

The existing pkgbuild scripts don't account for the VPN running with the app closed. 
In this scenario the `preinstall` script creates a marker file saying the VPN should be started in the `postinstall`. A marker file saying the app is running is not created. 
Then, in the `postinstall` the VPN is started, but not the app. When the user does launch the app, the network extension is upgraded whilst the VPN is running, and the linked issue occurs.

It's not possible to write a bash script that waits for not only the app to launch, but for the network extension replacement request to be sent and handled.
However, we already do this in  Swift code. If `Start Coder Connect on launch` is toggled on, the VPN won't be started until it is absolutely safe to do so.
<img width="604" alt="image" src="https://github.com/user-attachments/assets/010446b6-be33-47f0-9e59-4131f89d46a0" />

Therefore, we'll remove the portion of the pkgbuild scripts responsible for turning the VPN on after upgrade. If users want this behaviour, they can just toggle it on in settings.