### PR TITLE
chore: dont stop coder connect on device sleep

### DIFF
--- a/Coder-Desktop/VPN/Manager.swift
+++ b/Coder-Desktop/VPN/Manager.swift
@@ -32,10 +32,9 @@ actor Manager {
             let sessionConfig = URLSessionConfiguration.default
             // The tunnel might be asked to start before the network interfaces have woken up from sleep
             sessionConfig.waitsForConnectivity = true
-            // URLSession's waiting for connectivity sometimes hangs even when
-            // the network is up so this is deliberately short (30s) to avoid a
-            // poor UX where it appears stuck.
-            sessionConfig.timeoutIntervalForResource = 30
+            // Timeout after 5 minutes, or if there's no data for 60 seconds
+            sessionConfig.timeoutIntervalForRequest = 60
+            sessionConfig.timeoutIntervalForResource = 300
             try await download(src: dylibPath, dest: dest, urlSession: URLSession(configuration: sessionConfig))
         } catch {
             throw .download(error)


### PR DESCRIPTION
Closes #88.

With https://github.com/coder/internal/issues/563 resolved, there's no need to stop the VPN on sleep, as when the device wakes the tunnel will have the correct workspace & agent state.

However, if the Coder deployment doesn't include the patch in https://github.com/coder/coder/pull/17598 (presumably v2.23 or later), the UI state will go out of sync when the device is slept or internet connection is lost. I think this is fine honestly, and I don't think it's worth doing a server version check to determine whether we should stop the VPN on sleep.