### PR TITLE
feat: show an alert when the menu bar icon is hidden

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -126,6 +126,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {
         false
     }
+
+    func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows _: Bool) -> Bool {
+        if !state.skipHiddenIconAlert, let menuBar, !menuBar.menuBarExtra.isVisible {
+            displayIconHiddenAlert()
+        }
+        return true
+    }
+
+    private func displayIconHiddenAlert() {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Coder Desktop is hidden!"
+        alert.informativeText = """
+        Coder Desktop is running, but there's no space in the menu bar for it's icon.
+        You can rearrange icons by holding command.
+        """
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Don't show again")
+        let resp = alert.runModal()
+        if resp == .alertSecondButtonReturn {
+            state.skipHiddenIconAlert = true
+        }
+    }
 }
 
 extension AppDelegate {

--- a/Coder-Desktop/Coder-Desktop/State.swift
+++ b/Coder-Desktop/Coder-Desktop/State.swift
@@ -69,6 +69,13 @@ class AppState: ObservableObject {
         }
     }
 
+    @Published var skipHiddenIconAlert: Bool = UserDefaults.standard.bool(forKey: Keys.skipHiddenIconAlert) {
+        didSet {
+            guard persistent else { return }
+            UserDefaults.standard.set(skipHiddenIconAlert, forKey: Keys.skipHiddenIconAlert)
+        }
+    }
+
     func tunnelProviderProtocol() -> NETunnelProviderProtocol? {
         if !hasSession { return nil }
         let proto = NETunnelProviderProtocol()
@@ -209,6 +216,8 @@ class AppState: ObservableObject {
         static let literalHeaders = "LiteralHeaders"
         static let stopVPNOnQuit = "StopVPNOnQuit"
         static let startVPNOnLaunch = "StartVPNOnLaunch"
+
+        static let skipHiddenIconAlert = "SkipHiddenIconAlert"
     }
 }
 

--- a/Coder-Desktop/project.yml
+++ b/Coder-Desktop/project.yml
@@ -97,7 +97,7 @@ packages:
     # - Set onAppear/disappear handlers.
     # The upstream repo has a purposefully limited API
     url: https://github.com/coder/fluid-menu-bar-extra
-    revision: 96a861a
+    revision: 8e1d8b8
   KeychainAccess:
     url: https://github.com/kishikawakatsumi/KeychainAccess
     branch: e0c7eebc5a4465a3c4680764f26b7a61f567cdaf


### PR DESCRIPTION
Relates to #148.

If the menu bar icon is hidden (such as when behind the notch, or otherwise), reopening the app will display an alert that the icon is hidden.
There's also a button to not show the alert again.

I've also tested that this, and the 'Do not show again' button, work in a fresh VM.

This is the same as what Tailscale does:

https://github.com/user-attachments/assets/dae6d9ed-eab2-404f-8522-314042bdd1d8


