### PR TITLE
fix: handle missing workspace app `display_name`

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Views/VPN/WorkspaceAppIcon.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/WorkspaceAppIcon.swift
@@ -75,7 +75,8 @@ struct WorkspaceApp {
         sessionToken: String
     ) throws(WorkspaceAppError) {
         slug = original.slug
-        displayName = original.display_name
+        // Same behaviour as the web UI
+        displayName = original.display_name ?? original.slug
 
         guard original.external else {
             throw .isWebApp
@@ -196,7 +197,7 @@ func vscodeDisplayApp(hostname: String, baseIconURL: URL, path: String? = nil) -
 }
 
 func vscodeInsidersDisplayApp(hostname: String, baseIconURL: URL, path: String? = nil) -> WorkspaceApp {
-    let icon = baseIconURL.appendingPathComponent("/icon/code.svg")
+    let icon = baseIconURL.appendingPathComponent("/icon/code-insiders.svg")
     return WorkspaceApp(
         slug: "-vscode-insiders",
         displayName: "VS Code Insiders Desktop",

--- a/Coder-Desktop/Coder-DesktopTests/WorkspaceAppTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/WorkspaceAppTests.swift
@@ -137,7 +137,7 @@ struct WorkspaceAppTests {
         #expect(apps.count == 1)
         #expect(apps[0].slug == "-vscode-insiders")
         #expect(apps[0].displayName == "VS Code Insiders Desktop")
-        #expect(apps[0].icon?.absoluteString == "https://coder.example.com/icon/code.svg")
+        #expect(apps[0].icon?.absoluteString == "https://coder.example.com/icon/code-insiders.svg")
         #expect(
             apps[0].url.absoluteString == """
             vscode-insiders://vscode-remote/ssh-remote+test-workspace.coder.test//home/user

--- a/Coder-Desktop/CoderSDK/Workspace.swift
+++ b/Coder-Desktop/CoderSDK/Workspace.swift
@@ -56,11 +56,10 @@ public struct WorkspaceAgent: Codable, Identifiable, Sendable {
 
 public struct WorkspaceApp: Codable, Identifiable, Sendable {
     public let id: UUID
-    // Not `omitempty`, but `coderd` sends empty string if `command` is set
-    public var url: URL?
+    public var url: URL? // `omitempty`
     public let external: Bool
     public let slug: String
-    public let display_name: String
+    public let display_name: String? // `omitempty`
     public let command: String? // `omitempty`
     public let icon: URL? // `omitempty`
     public let subdomain: Bool


### PR DESCRIPTION
also uses `code-insiders.svg` for the VS Code insiders icon.

Context: https://github.com/coder/coder/pull/17700