### PR TITLE
fix: manually upgrade system extension

### DIFF
--- a/Coder-Desktop/Coder-Desktop/VPN/NetworkExtension.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/NetworkExtension.swift
@@ -58,8 +58,9 @@ extension CoderVPNService {
             try await tm.saveToPreferences()
             neState = .disabled
         } catch {
+            // This typically fails when the user declines the permission dialog
             logger.error("save tunnel failed: \(error)")
-            neState = .failed(error.localizedDescription)
+            neState = .failed("Failed to save tunnel: \(error.localizedDescription). Try logging in and out again.")
         }
     }
 

--- a/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
@@ -81,13 +81,12 @@ final class CoderVPNService: NSObject, VPNService {
     // systemExtnDelegate holds a reference to the SystemExtensionDelegate so that it doesn't get
     // garbage collected while the OSSystemExtensionRequest is in flight, since the OS framework
     // only stores a weak reference to the delegate.
-    var systemExtnDelegate: SystemExtensionDelegate<CoderVPNService>!
+    var systemExtnDelegate: SystemExtensionDelegate<CoderVPNService>?
 
     var serverAddress: String?
 
     override init() {
         super.init()
-        systemExtnDelegate = SystemExtensionDelegate(asyncDelegate: self)
     }
 
     func start() async {

--- a/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
@@ -81,12 +81,13 @@ final class CoderVPNService: NSObject, VPNService {
     // systemExtnDelegate holds a reference to the SystemExtensionDelegate so that it doesn't get
     // garbage collected while the OSSystemExtensionRequest is in flight, since the OS framework
     // only stores a weak reference to the delegate.
-    var systemExtnDelegate: SystemExtensionDelegate<CoderVPNService>?
+    var systemExtnDelegate: SystemExtensionDelegate<CoderVPNService>!
 
     var serverAddress: String?
 
     override init() {
         super.init()
+        systemExtnDelegate = SystemExtensionDelegate(asyncDelegate: self)
     }
 
     func start() async {

--- a/Coder-Desktop/Coder-Desktop/VPN/VPNSystemExtension.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNSystemExtension.swift
@@ -147,7 +147,6 @@ class SystemExtensionDelegate<AsyncDelegate: SystemExtensionAsyncRecorder>:
             OSSystemExtensionManager.shared.submitRequest(request)
         case .none:
             logger.warning("Received an unexpected request result")
-            break
         }
     }
 

--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
@@ -81,6 +81,21 @@ struct VPNMenu<VPN: VPNService, FS: FileSyncDaemon>: View {
                     }.buttonStyle(.plain)
                     TrayDivider()
                 }
+                // This shows when
+                // 1. The user is logged in
+                // 2. The network extension is installed
+                // 3. The VPN is unconfigured
+                // It's accompanied by a message in the VPNState view
+                // that the user needs to reconfigure.
+                if state.hasSession, vpn.state == .failed(.networkExtensionError(.unconfigured)) {
+                    Button {
+                        state.reconfigure()
+                    } label: {
+                        ButtonRowView {
+                            Text("Reconfigure VPN")
+                        }
+                    }.buttonStyle(.plain)
+                }
                 if vpn.state == .failed(.systemExtensionError(.needsUserApproval)) {
                     Button {
                         openSystemExtensionSettings()
@@ -128,7 +143,9 @@ struct VPNMenu<VPN: VPNService, FS: FileSyncDaemon>: View {
         vpn.state == .connecting ||
             vpn.state == .disconnecting ||
             // Prevent starting the VPN before the user has approved the system extension.
-            vpn.state == .failed(.systemExtensionError(.needsUserApproval))
+            vpn.state == .failed(.systemExtensionError(.needsUserApproval)) ||
+            // Prevent starting the VPN without a VPN configuration.
+            vpn.state == .failed(.networkExtensionError(.unconfigured))
     }
 }
 

--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNState.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNState.swift
@@ -17,6 +17,10 @@ struct VPNState<VPN: VPNService>: View {
                 Text("Sign in to use Coder Desktop")
                     .font(.body)
                     .foregroundColor(.secondary)
+            case (.failed(.networkExtensionError(.unconfigured)), _):
+                Text("The system VPN requires reconfiguration.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
             case (.disabled, _):
                 Text("Enable Coder Connect to see workspaces")
                     .font(.body)
@@ -38,7 +42,7 @@ struct VPNState<VPN: VPNService>: View {
                     .padding(.horizontal, Theme.Size.trayInset)
                     .padding(.vertical, Theme.Size.trayPadding)
                     .frame(maxWidth: .infinity)
-            default:
+            case (.connected, true):
                 EmptyView()
             }
         }


### PR DESCRIPTION
This PR addresses #121. The underlying bug is still present in macOS, this is just a workaround, so I'm leaving the issue open.

macOS calls `actionForReplacingExtension` whenever the version string(s) of the system extension living inside the Coder Desktop app bundle change.

i.e. When a new version of the app is installed:
1. App sends `activationRequest` (it does this on every launch, to see if the NE is installed)
2. Eventually, `actionForReplacingExtension` is called, which can either return `.cancel` or `.replace`.
3. Eventually,`didFinishWithResult` is called with whether the replacement was successful.

(`actionForReplacingExtension` is *always* called when developing the app locally, even if the version string(s) don't differ)

However, in the linked issue, we note that this replacement process is bug-prone. This bug can be worked around by deleting the system extension (in settings), and reactivating it (such as by relaunching the app).

Therefore, in this PR, when `didFinishWithResult` is called following a replacement request, we instead will:
1. Send a `deactivationRequest`, and wait for it to be successful.
2. Send another `activationRequest`, and wait for that to be successful.

Of note is that we *cannot* return `.cancel` from `actionForReplacingExtension` and then later send a `deactivationRequest`. `deactivationRequest` *always* searches for a system extension with version string(s) that match the system extension living inside the currently installed app bundle. Therefore, we have to let the replacement take place before attempting to delete it.

Also of note is that a successful `deactivationRequest` of the system extension deletes the corresponding VPN configuration. This configuration is normally created by logging in, but if the user is already logged in, we'll update the UI to include a `Reconfigure VPN` button.

<img width="263" alt="image" src="https://github.com/user-attachments/assets/d874821e-1696-4d17-bb3e-4ea83556f75c" />

I've tested this PR in a fresh macOS 15.4 VM, upgrading from the latest release. I also forced the bug in the linked issue to occur by toggling on the VPN in System Settings before opening the new version of the app for the first time, and going through all the additional prompts did indeed prevent the issue from happening.