### PR TITLE
fix: set network extension as unconfigured when system extension is deleted

### DIFF
--- a/Coder-Desktop/Coder-Desktop/VPN/VPNSystemExtension.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNSystemExtension.swift
@@ -63,6 +63,10 @@ extension CoderVPNService: SystemExtensionAsyncRecorder {
             // system extension was successfully installed, so we don't need the delegate any more
             systemExtnDelegate = nil
         }
+        if state == .uninstalled {
+            // System extension was deleted, and the VPN configurations go with it
+            neState = .unconfigured
+        }
     }
 
     func installSystemExtension() {


### PR DESCRIPTION
This fixes a bug when `Launch Coder Connect at startup` is enabled when updating the app with #161, where the app attempts to start too early, as it thinks the VPN is configured, but it was unconfigured with the deletion of the system extension.