### PR TITLE
fix: don't create http client if signed out

### DIFF
--- a/Coder-Desktop/Coder-Desktop/State.swift
+++ b/Coder-Desktop/Coder-Desktop/State.swift
@@ -120,6 +120,7 @@ class AppState: ObservableObject {
             _sessionToken = Published(initialValue: keychainGet(for: Keys.sessionToken))
             if sessionToken == nil || sessionToken!.isEmpty == true {
                 clearSession()
+                return
             }
             client = Client(
                 url: baseAccessURL!,


### PR DESCRIPTION
If the session item in the keychain is missing but `hasSession` is true, the app will force unwrap the session token optional and crash on launch. Encountered this today.