### PR TITLE
ci: remove cache-nix-action

### DIFF
--- a/.github/actions/nix-devshell/action.yaml
+++ b/.github/actions/nix-devshell/action.yaml
@@ -6,7 +6,7 @@ runs:
     - name: Setup Nix
       uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
 
-    - uses: nix-community/cache-nix-action@92aaf15ec4f2857ffed00023aecb6504bb4a5d3d # v6
+    - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
       with:
         # restore and save a cache using this key
         primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}

--- a/.github/actions/nix-devshell/action.yaml
+++ b/.github/actions/nix-devshell/action.yaml
@@ -6,6 +6,7 @@ runs:
     - name: Setup Nix
       uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
 
+    # Using the cache is somehow slower, so we're not using it for now.
     # - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
     #   with:
     #     # restore and save a cache using this key

--- a/.github/actions/nix-devshell/action.yaml
+++ b/.github/actions/nix-devshell/action.yaml
@@ -6,24 +6,24 @@ runs:
     - name: Setup Nix
       uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
 
-    - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
-      with:
-        # restore and save a cache using this key
-        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-        # if there's no cache hit, restore a cache by this prefix
-        restore-prefixes-first-match: nix-${{ runner.os }}-
-        # collect garbage until Nix store size (in bytes) is at most this number
-        # before trying to save a new cache
-        # 1 GB = 1073741824 B
-        gc-max-store-size-linux: 1073741824
-        # do purge caches
-        purge: true
-        # purge all versions of the cache
-        purge-prefixes: nix-${{ runner.os }}-
-        # created more than this number of seconds ago relative to the start of the `Post Restore` phase
-        purge-created: 0
-        # except the version with the `primary-key`, if it exists
-        purge-primary-key: never
+    # - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
+    #   with:
+    #     # restore and save a cache using this key
+    #     primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+    #     # if there's no cache hit, restore a cache by this prefix
+    #     restore-prefixes-first-match: nix-${{ runner.os }}-
+    #     # collect garbage until Nix store size (in bytes) is at most this number
+    #     # before trying to save a new cache
+    #     # 1 GB = 1073741824 B
+    #     gc-max-store-size-linux: 1073741824
+    #     # do purge caches
+    #     purge: true
+    #     # purge all versions of the cache
+    #     purge-prefixes: nix-${{ runner.os }}-
+    #     # created more than this number of seconds ago relative to the start of the `Post Restore` phase
+    #     purge-created: 0
+    #     # except the version with the `primary-key`, if it exists
+    #     purge-primary-key: never
 
     - name: Enter devshell
       uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1


### PR DESCRIPTION
It's twice as fast without the cache

With cache:
<img width="296" alt="image" src="https://github.com/user-attachments/assets/865bfbaf-774d-4213-ba99-b338dbef13dd" />


Without:
<img width="296" alt="image" src="https://github.com/user-attachments/assets/e55be0dd-bd4e-472f-af4c-c5d06f7ef7ad" />

I can only assume it's just faster to compile some of the dependencies then to copy them from the cache