### PR TITLE
chore: append bundle version to mach service name

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Info.plist
+++ b/Coder-Desktop/Coder-Desktop/Info.plist
@@ -29,7 +29,12 @@
 	<key>NetworkExtension</key>
 	<dict>
 		<key>NEMachServiceName</key>
-		<string>$(TeamIdentifierPrefix)com.coder.Coder-Desktop.VPN</string>
+		<!-- We append the CFBundleVersion to the service name to ensure a new
+		 service is used for each version. This works around the issue described
+		 in https://github.com/coder/coder-desktop-macos/issues/121, presumably
+		 caused by the XPC service cache not being invalidated on update.
+		-->
+		<string>$(TeamIdentifierPrefix)com.coder.Coder-Desktop.VPN.$(CURRENT_PROJECT_VERSION)</string>
 	</dict>
 	<key>SUPublicEDKey</key>
 	<string>Ae2oQLTcx89/a73XrpOt+IVvqdo+fMTjo3UKEm77VdA=</string>

--- a/Coder-Desktop/Coder-Desktop/VPN/VPNSystemExtension.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNSystemExtension.swift
@@ -183,6 +183,7 @@ class SystemExtensionDelegate<AsyncDelegate: SystemExtensionAsyncRecorder>:
         if existing.bundleVersion == `extension`.bundleVersion {
             return .replace
         }
+        // TODO: Workaround disabled, as we're trying another workaround
         // To work around the bug described in
         // https://github.com/coder/coder-desktop-macos/issues/121,
         // we're going to manually reinstall after the replacement is done.
@@ -190,8 +191,8 @@ class SystemExtensionDelegate<AsyncDelegate: SystemExtensionAsyncRecorder>:
         // it looks for an extension with the *current* version string.
         // There's no way to modify the deactivate request to use a different
         // version string (i.e. `existing.bundleVersion`).
-        logger.info("App upgrade detected, replacing and then reinstalling")
-        action = .replacing
+        // logger.info("App upgrade detected, replacing and then reinstalling")
+        // action = .replacing
         return .replace
     }
 }

--- a/Coder-Desktop/VPN/Info.plist
+++ b/Coder-Desktop/VPN/Info.plist
@@ -9,7 +9,12 @@
 	<key>NetworkExtension</key>
 	<dict>
 		<key>NEMachServiceName</key>
-		<string>$(TeamIdentifierPrefix)com.coder.Coder-Desktop.VPN</string>
+		<!-- We append the CFBundleVersion to the service name to ensure a new
+		 service is used for each version. This works around the issue described
+		 in https://github.com/coder/coder-desktop-macos/issues/121, presumably
+		 caused by the XPC service cache not being invalidated on update.
+		-->
+		<string>$(TeamIdentifierPrefix)com.coder.Coder-Desktop.VPN.$(CURRENT_PROJECT_VERSION)</string>
 		<key>NEProviderClasses</key>
 		<dict>
 			<key>com.apple.networkextension.packet-tunnel</key>


### PR DESCRIPTION
We append the CFBundleVersion to the service name to ensure a new service is used for each version. This works around the issue described in https://github.com/coder/coder-desktop-macos/issues/121, presumably caused by the XPC service cache not being invalidated on update.

![image](https://github.com/user-attachments/assets/5b1f2d1d-7aa1-4f58-92b0-ecee712f9131)
