### PR TITLE
chore: bring app to front when an update is available

### DIFF
--- a/Coder-Desktop/Coder-Desktop/UpdaterService.swift
+++ b/Coder-Desktop/Coder-Desktop/UpdaterService.swift
@@ -64,7 +64,7 @@ extension UpdaterService: SPUUpdaterDelegate {
         [updateChannel.rawValue]
     }
 
-    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+    func updater(_: SPUUpdater, didFindValidUpdate _: SUAppcastItem) {
         Task { @MainActor in appActivate() }
     }
 }


### PR DESCRIPTION
Supposedly users are missing the notification because it's just silently appearing in the background.