### PR TITLE
fix: prompt for sign in when toggling coder connect on

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
@@ -117,12 +117,15 @@ struct VPNMenu<VPN: VPNService, FS: FileSyncDaemon>: View {
     }
 
     private var vpnDisabled: Bool {
-        vpn.state == .connecting ||
-            vpn.state == .disconnecting ||
-            // Prevent starting the VPN before the user has approved the system extension.
-            vpn.state == .failed(.systemExtensionError(.needsUserApproval)) ||
-            // Prevent starting the VPN without a VPN configuration.
-            vpn.state == .failed(.networkExtensionError(.unconfigured))
+        // Always enabled if signed out, as that will open the sign in window
+        state.hasSession && (
+            vpn.state == .connecting ||
+                vpn.state == .disconnecting ||
+                // Prevent starting the VPN before the user has approved the system extension.
+                vpn.state == .failed(.systemExtensionError(.needsUserApproval)) ||
+                // Prevent starting the VPN without a VPN configuration.
+                vpn.state == .failed(.networkExtensionError(.unconfigured))
+        )
     }
 }
 

--- a/Coder-Desktop/Coder-DesktopTests/VPNMenuTests.swift
+++ b/Coder-Desktop/Coder-DesktopTests/VPNMenuTests.swift
@@ -33,6 +33,21 @@ struct VPNMenuTests {
     }
 
     @Test
+    func testVPNLoggedOutUnconfigured() async throws {
+        vpn.state = .failed(.networkExtensionError(.unconfigured))
+        try await ViewHosting.host(view) {
+            try await sut.inspection.inspect { view in
+                let toggle = try view.find(ViewType.Toggle.self)
+                // Toggle should be enabled even with a failure that would
+                // normally make it disabled, because we're signed out.
+                #expect(!toggle.isDisabled())
+                #expect(throws: Never.self) { try view.find(text: "Sign in to use Coder Desktop") }
+                #expect(throws: Never.self) { try view.find(button: "Sign in") }
+            }
+        }
+    }
+
+    @Test
     func testStartStopCalled() async throws {
         try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
@@ -59,6 +74,7 @@ struct VPNMenuTests {
     @Test
     func testVPNDisabledWhileConnecting() async throws {
         vpn.state = .disabled
+        state.login(baseAccessURL: URL(string: "https://coder.example.com")!, sessionToken: "fake-token")
 
         try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in
@@ -79,6 +95,7 @@ struct VPNMenuTests {
     @Test
     func testVPNDisabledWhileDisconnecting() async throws {
         vpn.state = .disabled
+        state.login(baseAccessURL: URL(string: "https://coder.example.com")!, sessionToken: "fake-token")
 
         try await ViewHosting.host(view) {
             try await sut.inspection.inspect { view in


### PR DESCRIPTION
I undid the work of #114 in #158, by disabling the VPN toggle when the network extension was unconfigured.
When signed out, the network extension is unconfigured.
This PR adds a special exception to make the VPN toggle always clickable when signed out, as it has special behaviour when signed out.
It also adds a proper regression test. A slightly different regression test existed, but it didn't account for cases where the VPN state is one that would normally disable the toggle.