### PR TITLE
chore: improve vpn configuration errors

### DIFF
--- a/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
@@ -37,7 +37,7 @@ enum VPNServiceError: Error, Equatable {
     case systemExtensionError(SystemExtensionState)
     case networkExtensionError(NetworkExtensionState)
 
-    var description: String {
+    public var description: String {
         switch self {
         case let .internalError(description):
             "Internal Error: \(description)"
@@ -48,7 +48,7 @@ enum VPNServiceError: Error, Equatable {
         }
     }
 
-    var localizedDescription: String { description }
+    public var localizedDescription: String { description }
 }
 
 @MainActor
@@ -126,13 +126,13 @@ final class CoderVPNService: NSObject, VPNService {
                 // this just configures the VPN, it doesn't enable it
                 tunnelState = .disabled
             } else {
-                do {
+                do throws(VPNServiceError) {
                     try await removeNetworkExtension()
                     neState = .unconfigured
                     tunnelState = .disabled
                 } catch {
-                    logger.error("failed to remove network extension: \(error)")
-                    neState = .failed(error.localizedDescription)
+                    logger.error("failed to remove configuration: \(error)")
+                    neState = .failed("Failed to remove configuration: \(error.description)")
                 }
             }
         }

--- a/Coder-Desktop/project.yml
+++ b/Coder-Desktop/project.yml
@@ -98,7 +98,7 @@ packages:
     # - Set onAppear/disappear handlers.
     # The upstream repo has a purposefully limited API
     url: https://github.com/coder/fluid-menu-bar-extra
-    revision: 8e1d8b8
+    revision: b0d5438
   KeychainAccess:
     url: https://github.com/kishikawakatsumi/KeychainAccess
     branch: e0c7eebc5a4465a3c4680764f26b7a61f567cdaf


### PR DESCRIPTION
Some flakey OS operation has been reported by two different users after installation:
<img width="215" height="415" alt="image" src="https://github.com/user-attachments/assets/e632071d-02a3-45d3-bbef-f1bce9139974" />
<img width="247" height="191" alt="image" src="https://github.com/user-attachments/assets/dcd4b39b-5be4-4630-a4c8-dc45fe06bb77" />

I don't know what's happening because the error handling here isn't very good. This PR fixes that by always including the operation that failed in the UI message.