### PR TITLE
chore: ensure downloaded slim binary version matches server

### DIFF
--- a/Coder-Desktop/Coder-DesktopHelper/Manager.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/Manager.swift
@@ -76,7 +76,8 @@ actor Manager {
         }
         pushProgress(stage: .validating)
         do {
-            try Validator.validate(path: dest)
+            try Validator.validateSignature(binaryPath: dest)
+            try await Validator.validateVersion(binaryPath: dest, serverVersion: buildInfo.version)
         } catch {
             // Cleanup unvalid binary
             try? FileManager.default.removeItem(at: dest)


### PR DESCRIPTION
Relates to #201.

**After we've validated the binary signature**, we exec `coder version --output=json` to validate the version of the downloaded binary matches the server. This is done to prevent against downgrade attacks, and to match the checking we had on the dylib before.


Additionally, this PR also ensures the certificate used to sign the binary is part of an Apple-issued certificate chain.

I assumed we were checking this before (by default) but we weren't. 
Though we weren't previously checking it, we were only ever downloading and executing a dylib. 
My understanding is that macOS won't execute a dylib unless the executing process and the dylib were signed by the same Apple developer team (at [least in a sandboxed process](https://developer.apple.com/forums/thread/683914), as is the Network Extension).

Only now, when `posix_spawn`ing the slim binary from an unsandboxed LaunchDaemon, is this check absolutely necessary.