### PR TITLE
fix: always open app as logged-in user in postinstall script

### DIFF
--- a/pkgbuild/scripts/postinstall
+++ b/pkgbuild/scripts/postinstall
@@ -32,7 +32,10 @@ spctl -avvv "/Applications/Coder Desktop.app/Contents/Library/SystemExtensions/c
 # Restart Coder Desktop if it was running before
 if [ -f "$RUNNING_MARKER_FILE" ]; then
   echo "Starting Coder Desktop..."
-  open -a "Coder Desktop"
+  # When deploying the app via MDM, this script runs as root. The app cannot
+  # function properly when launched as root.
+  currentUser=$(/usr/bin/stat -f "%Su" /dev/console)
+  /bin/launchctl asuser "$( /usr/bin/id -u "$currentUser")" /usr/bin/open "/Applications/Coder Desktop.app"
   rm "$RUNNING_MARKER_FILE"
   echo "Coder Desktop started."
 fi


### PR DESCRIPTION
This PR prevents issues like:

<img width="428" height="171" alt="Screenshot 2025-07-30 at 3 57 07 pm" src="https://github.com/user-attachments/assets/729055b8-bc9b-43fc-9e95-ed9faa384872" />

which occur when the app is launched as root. This can happen when the installer scripts are run as root, which is the case when deploying Coder Desktop over MDM. (As a convenience, we re-open the app if it was open before the installer was ran.)

Of note is that on macOS, it is not sufficient to just run open with `sudo -u`, as that does not use the execution context of the user. See https://developer.apple.com/forums/thread/78332


Reports of the bug in other programs:
(with an incorrect solution) https://community.zoom.com/t5/Zoom-Meetings/A-keychain-cannot-be-found-to-stoer-quot-Zoom-quot/m-p/51059 
https://displaylink.org/forum/showthread.php?p=97176




