### PR TITLE
feat: support http coder urls

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Views/LoginForm.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/LoginForm.swift
@@ -194,8 +194,8 @@ func validateURL(_ url: String) throws(LoginError) -> URL {
     guard let url = URL(string: url) else {
         throw .invalidURL
     }
-    guard url.scheme == "https" else {
-        throw .httpsRequired
+    guard url.scheme == "https" || url.scheme == "http" else {
+        throw .invalidScheme
     }
     guard url.host != nil else {
         throw .noHost
@@ -204,7 +204,7 @@ func validateURL(_ url: String) throws(LoginError) -> URL {
 }
 
 enum LoginError: Error {
-    case httpsRequired
+    case invalidScheme
     case noHost
     case invalidURL
     case outdatedCoderVersion
@@ -213,12 +213,12 @@ enum LoginError: Error {
 
     var description: String {
         switch self {
-        case .httpsRequired:
-            "URL must use HTTPS"
+        case .invalidScheme:
+            "Coder URL must use HTTPS or HTTP"
         case .noHost:
-            "URL must have a host"
+            "Coder URL must have a host"
         case .invalidURL:
-            "Invalid URL"
+            "Invalid Coder URL"
         case .outdatedCoderVersion:
             """
             The Coder deployment must be version \(Validator.minimumCoderVersion)


### PR DESCRIPTION
Currently, in the Login Form, we reject non-https URLs. When this HTTPS requirement was added, the Coder Desktop app was unable to make HTTP requests, as it did not have `NSArbitraryLoads`. We ended up needing to enable that flag in order to use the Agent API. (`http://workspace.coder:4`)

To support Coder deployments behind VPNs without HTTPS, we can now loosen the requirement. With this PR, the behavior [matches Windows.](https://github.com/coder/coder-desktop-windows/blob/ac22fe4c44dea03b21557b4a0f1e214397bc3ea4/App/Services/CredentialManager.cs#L175-L176)