### PR TITLE
fix: avoid automatically reconfiguring vpn

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNState.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNState.swift
@@ -28,10 +28,6 @@ struct VPNState<VPN: VPNService>: View {
                     } label: {
                         Text("Reconfigure VPN")
                     }
-                }.onAppear {
-                    // Show the prompt onAppear, so the user doesn't have to
-                    // open the menu bar an extra time
-                    state.reconfigure()
                 }
             case (.disabled, _):
                 Text("Enable Coder Connect to see workspaces")


### PR DESCRIPTION
I added this block of code as a convenience, during the time we were using a workaround for the XPC issue that involved deleting and reinserting the network extension when updated. This block of code meant the user didn't need to click back into the tray menu to get the VPN configuration prompt to appear, it would just appear as soon as necessary.

However, this introduces a race. If the app loads the VPN unconfigured view before the task that checks for an existing VPN configuration finishes (this task runs as part of `applicationDidFinishLaunching`), the user will be displayed the prompt to reconfigure, even if a valid configuration already exists.

Since we're not using the aforementioned workaround, this convenience is no longer necessary, and can be removed as the race is more likely to be an issue.