### PR TITLE
ci: fix typo in brew cask zap stanza

### DIFF
--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -100,7 +100,7 @@ cask "coder-desktop" do
 
   zap delete: [
         "/var/root/Library/Application Support/com.coder.Coder-Desktop/coder-darwin-arm64",
-        "/var/root/Library/Application Support/com.coder.Coder-Desktop/coder-darwin_amd64",
+        "/var/root/Library/Application Support/com.coder.Coder-Desktop/coder-darwin-amd64",
         "/var/root/Library/Containers/com.Coder-Desktop.VPN/Data/Documents/coder-vpn.dylib",
       ],
       trash:  [


### PR DESCRIPTION
Noticed when making the new release that this was wrong... Obviously not essential since I assume everyone's on arm64 these days.