### PR TITLE
feat: dynamically show app in dock & cmd+tab

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -20,6 +20,7 @@ struct DesktopApp: App {
         Window("Sign In", id: Windows.login.rawValue) {
             LoginForm()
                 .environmentObject(appDelegate.state)
+                .showDockIconWhenOpen()
         }.handlesExternalEvents(matching: Set()) // Don't handle deep links
             .windowResizability(.contentSize)
         SwiftUI.Settings {
@@ -27,6 +28,7 @@ struct DesktopApp: App {
                 .environmentObject(appDelegate.vpn)
                 .environmentObject(appDelegate.state)
                 .environmentObject(appDelegate.autoUpdater)
+                .showDockIconWhenOpen()
         }
         .windowResizability(.contentSize)
         Window("Coder File Sync", id: Windows.fileSync.rawValue) {
@@ -34,6 +36,7 @@ struct DesktopApp: App {
                 .environmentObject(appDelegate.state)
                 .environmentObject(appDelegate.fileSyncDaemon)
                 .environmentObject(appDelegate.vpn)
+                .showDockIconWhenOpen()
         }.handlesExternalEvents(matching: Set()) // Don't handle deep links
     }
 }

--- a/Coder-Desktop/Coder-Desktop/Views/Util.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/Util.swift
@@ -44,3 +44,26 @@ public extension View {
         }
     }
 }
+
+@MainActor
+private struct ActivationPolicyModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            // This lets us show and hide the app from the dock and cmd+tab
+            // when a window is open.
+            .onAppear {
+                NSApp.setActivationPolicy(.regular)
+            }
+            .onDisappear {
+                if NSApp.windows.filter { $0.level != .statusBar && $0.isVisible }.count <= 1 {
+                    NSApp.setActivationPolicy(.accessory)
+                }
+            }
+    }
+}
+
+public extension View {
+    func showDockIconWhenOpen() -> some View {
+        modifier(ActivationPolicyModifier())
+    }
+}


### PR DESCRIPTION
This was requested once or twice, but until I saw Tailscale do it I thought it wasn't possible! The main motivation is so you can cmd+tab back into the sign in window once you have the token, or click the dock icon.

Pretty sure this is the same way Tailscale does it.


https://github.com/user-attachments/assets/a2e6a5de-dc4b-4cf3-8896-2255381efa9e



