### PR TITLE
feat: implement keyboard shortcuts helpers to `VPNMenu()`

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenu.swift
@@ -86,8 +86,14 @@ struct VPNMenu<VPN: VPNService, FS: FileSyncDaemon>: View {
                     openSettings()
                     appActivate()
                 } label: {
-                    ButtonRowView { Text("Settings") }
-                }.buttonStyle(.plain)
+                    ButtonRowView {
+                        HStack {
+                            Text("Settings")
+                            Spacer()
+                            Text("⌘,").foregroundStyle(.secondary)
+                        }
+                    }
+                }.buttonStyle(.plain).keyboardShortcut(",", modifiers: [.command])
                 Button {
                     About.open()
                 } label: {
@@ -100,9 +106,13 @@ struct VPNMenu<VPN: VPNService, FS: FileSyncDaemon>: View {
                     NSApp.terminate(nil)
                 } label: {
                     ButtonRowView {
-                        Text("Quit")
+                        HStack {
+                            Text("Quit")
+                            Spacer()
+                            Text("⌘Q").foregroundStyle(.secondary)
+                        }
                     }
-                }.buttonStyle(.plain)
+                }.buttonStyle(.plain).keyboardShortcut("q", modifiers: [.command])
             }.padding([.horizontal, .bottom], Theme.Size.trayMargin)
         }.padding(.bottom, Theme.Size.trayMargin)
             .environmentObject(vpn)


### PR DESCRIPTION
Adds shortcut indicators (`⌘,` and `⌘Q`) to the Coder Desktop context menu to make keyboard actions more discoverable.

Because the menu is rendered using `FluidMenuBarExtra` (custom SwiftUI content), we can’t rely on native `.commands` shortcut rendering. As a result, these indicators are displayed manually rather than using the system-provided shortcut column.

<img width="302" height="341" alt="image" src="https://github.com/user-attachments/assets/081331aa-223d-4c4d-95ae-0dfc2eac63cf" />
