### PR TITLE
fix: update messaging in menubar icon missing

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -178,7 +178,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         alert.messageText = "Coder Desktop is hidden!"
         if #available(macOS 26, *) {
             alert.informativeText = """
-            Coder Desktop is already running, but its menu bar item may be disabled, or hidden due to a lack of space. 
+            Coder Desktop is already running, but its menu bar item may be disabled, or hidden due to a lack of space.
             You can rearrange icons by holding command.
             """
             alert.addButton(withTitle: "Open Menu Bar Settings")

--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -178,7 +178,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         alert.messageText = "Coder Desktop is hidden!"
         if #available(macOS 26, *) {
             alert.informativeText = """
-            Coder Desktop is already running, but its menu bar item may be hidden or disabled.
+            Coder Desktop is already running, but its menu bar item may be disabled, or hidden due to a lack of space. 
+            You can rearrange icons by holding command.
             """
             alert.addButton(withTitle: "Open Menu Bar Settings")
         } else {

--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -147,7 +147,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows _: Bool) -> Bool {
-        if !state.skipHiddenIconAlert, let menuBar, !menuBar.menuBarExtra.isVisible {
+        if !state.skipHiddenIconAlert,
+           let menuBar,
+           !menuBar.menuBarExtra.isVisible
+        {
             displayIconHiddenAlert()
         }
         return true
@@ -173,15 +176,33 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let alert = NSAlert()
         alert.alertStyle = .informational
         alert.messageText = "Coder Desktop is hidden!"
-        alert.informativeText = """
-        Coder Desktop is running, but there's no space in the menu bar for it's icon.
-        You can rearrange icons by holding command.
-        """
+        if #available(macOS 26, *) {
+            alert.informativeText = """
+            Coder Desktop is already running, but its menu bar item may be hidden or disabled.
+            """
+            alert.addButton(withTitle: "Open Menu Bar Settings")
+        } else {
+            alert.informativeText = """
+            Coder Desktop is already running, but there's no space in the menu bar for its icon.
+            """
+        }
+
+        let suppressCheckbox = NSButton(checkboxWithTitle: "Don't show again", target: nil, action: nil)
+        suppressCheckbox.state = state.skipHiddenIconAlert ? .on : .off
+        alert.accessoryView = suppressCheckbox
+
         alert.addButton(withTitle: "OK")
-        alert.addButton(withTitle: "Don't show again")
-        let resp = alert.runModal()
-        if resp == .alertSecondButtonReturn {
-            state.skipHiddenIconAlert = true
+        let response = alert.runModal()
+        state.skipHiddenIconAlert = suppressCheckbox.state == .on
+        if #available(macOS 26, *), response == .alertFirstButtonReturn {
+            // We'll need to ensure this continues to work in future macOS versions
+            if !NSWorkspace.shared.open(
+                URL(string: "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension?MenuBar")!
+            ) {
+                NSWorkspace.shared.open(
+                    URL(string: "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension")!
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
This pull-request alerts users that they may have disabled the menubar icon for Coder Desktop when they attempt to use the application (but obviously only for newer versions of MacOS Tahoe and above). We've added a button to quickly link into the Settings page if they are on a version that supports this and moved the "Don't tell me again" to a checkbox so its not its own dedicated button now.

https://github.com/user-attachments/assets/3e34ef4d-485f-4ec4-aa07-e7d54ea94edc