### PR TITLE
feat: add `.help()` for workspace name

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenuItem.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenuItem.swift
@@ -95,6 +95,10 @@ struct MenuItemView: View {
         return formattedName
     }
 
+    private var fullItemName: String {
+        item.primaryHost(hostnameSuffix: state.hostnameSuffix)
+    }
+
     private var isExpanded: Bool {
         expandedItem == item.id
     }
@@ -134,6 +138,7 @@ struct MenuItemView: View {
                         .onHover { hovering in
                             nameIsSelected = hovering
                         }
+                        .help(fullItemName)
                 }.buttonStyle(.plain).padding(.trailing, 3)
                 MenuItemIcons(item: item, wsURL: wsURL)
             }

--- a/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenuItem.swift
+++ b/Coder-Desktop/Coder-Desktop/Views/VPN/VPNMenuItem.swift
@@ -83,20 +83,18 @@ struct MenuItemView: View {
 
     var hasApps: Bool { !apps.isEmpty }
 
-    private var itemName: AttributedString {
-        let name = item.primaryHost(hostnameSuffix: state.hostnameSuffix)
+    private var plainItemName: String {
+        item.primaryHost(hostnameSuffix: state.hostnameSuffix)
+    }
 
-        var formattedName = AttributedString(name)
+    private var itemName: AttributedString {
+        var formattedName = AttributedString(plainItemName)
         formattedName.foregroundColor = .primary
 
         if let range = formattedName.range(of: ".\(state.hostnameSuffix)", options: .backwards) {
             formattedName[range].foregroundColor = .secondary
         }
         return formattedName
-    }
-
-    private var fullItemName: String {
-        item.primaryHost(hostnameSuffix: state.hostnameSuffix)
     }
 
     private var isExpanded: Bool {
@@ -138,7 +136,7 @@ struct MenuItemView: View {
                         .onHover { hovering in
                             nameIsSelected = hovering
                         }
-                        .help(fullItemName)
+                        .help(plainItemName)
                 }.buttonStyle(.plain).padding(.trailing, 3)
                 MenuItemIcons(item: item, wsURL: wsURL)
             }
@@ -228,9 +226,12 @@ struct MenuItemIcons: View {
     @State private var webIsSelected: Bool = false
 
     func copyToClipboard() {
-        let primaryHost = item.primaryHost(hostnameSuffix: state.hostnameSuffix)
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(primaryHost, forType: .string)
+        NSPasteboard.general.setString(plainItemName, forType: .string)
+    }
+
+    private var plainItemName: String {
+        item.primaryHost(hostnameSuffix: state.hostnameSuffix)
     }
 
     var body: some View {


### PR DESCRIPTION
This pull-request makes it so that on hover we show the full workspace name. This allows the user to distinguish between similarly named workspaces when they're side by side. 

<img width="298" height="190" alt="image" src="https://github.com/user-attachments/assets/c858ad93-afe6-4d5a-a1d8-af034b95d5bf" />
