### PR TITLE
feat: implement MacOS 26 Tahoe liquid glass improvements

### DIFF
--- a/Coder-Desktop/project.yml
+++ b/Coder-Desktop/project.yml
@@ -101,7 +101,7 @@ packages:
     # - Set onAppear/disappear handlers.
     # The upstream repo has a purposefully limited API
     url: https://github.com/coder/fluid-menu-bar-extra
-    revision: b0d5438
+    revision: 5b131c7
   KeychainAccess:
     url: https://github.com/kishikawakatsumi/KeychainAccess
     branch: e0c7eebc5a4465a3c4680764f26b7a61f567cdaf


### PR DESCRIPTION
> [!NOTE]  
> This pull-request is dependent on [`coder/fluid-menu-bar-extra#4`](https://github.com/coder/fluid-menu-bar-extra/pull/4), keeping in draft until this upstream dependency is merged. And #248 waiting for the Xcode runners to be updated.

This pull-request takes our [`coder/fluid-menu-bar-extra#4`](https://github.com/coder/fluid-menu-bar-extra/pull/4) pull-request and applies it to our `coder/coder-desktop-macos` codebase so that we can take advantage of the new MacOS 26+ Liquid Glass design.

Screenshots are lacking as the change is very subtle unless looking on distinct backgrounds.