### PR TITLE
ci: make generated cask pass `brew style`

### DIFF
--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -87,7 +87,7 @@ cask "coder-desktop" do
   homepage "https://github.com/coder/coder-desktop-macos"
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   pkg "Coder-Desktop.pkg"
 
@@ -99,8 +99,8 @@ cask "coder-desktop" do
             login_item: "Coder Desktop"
 
   zap delete: [
-        "/var/root/Library/Application Support/com.coder.Coder-Desktop/coder-darwin-arm64",
         "/var/root/Library/Application Support/com.coder.Coder-Desktop/coder-darwin-amd64",
+        "/var/root/Library/Application Support/com.coder.Coder-Desktop/coder-darwin-arm64",
         "/var/root/Library/Containers/com.Coder-Desktop.VPN/Data/Documents/coder-vpn.dylib",
       ],
       trash:  [


### PR DESCRIPTION
The cask emitted by `scripts/update-cask.sh` (invoked from the `update-cask` job in `.github/workflows/release.yml`) currently fails `brew test-bot --only-tap-syntax` on the homebrew-coder side. See [this run](https://github.com/coder/homebrew-coder/actions/runs/26144340201/job/76896247127?pr=360), which blocked [coder/homebrew-coder#360](https://github.com/coder/homebrew-coder/pull/360) for the `v0.8.1` release.

Two autocorrectable `brew style` offenses, both originating from the heredoc in `scripts/update-cask.sh`:

- `Homebrew/OSDependsOn`: prefer the symbol form `depends_on macos: :sonoma` over `">= :sonoma"` (semantically equivalent — still means "Sonoma or newer").
- `Cask/ArrayAlphabetization`: the `zap delete:` array must be ordered alphabetically, so `coder-darwin-amd64` belongs before `coder-darwin-arm64`.

The corresponding open PR on coder/homebrew-coder has already been amended directly with the same two-line fix to unblock the v0.8.1 release. This PR ensures future releases generate a cask that passes `brew style` without manual cleanup.