### PR TITLE
ci: explain /Applications requirement in cask caveats

### DIFF
--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -108,6 +108,13 @@ cask "coder-desktop" do
         "~/Library/HTTPStorages/com.coder.Coder-Desktop",
         "~/Library/Preferences/com.coder.Coder-Desktop.plist",
       ]
+
+  caveats <<~CAVEATS
+    Coder Desktop must be installed in /Applications because it contains a
+    System Network Extension, which macOS only activates when the containing
+    app lives in /Applications. As this cask uses a \`pkg\` installer,
+    HOMEBREW_CASK_OPTS=--appdir has no effect.
+  CAVEATS
 end
 EOF
 


### PR DESCRIPTION
Fixes #255.

## What

Adds a `caveats` stanza to the generated `coder-desktop` cask that explains why the app installs to `/Applications` and why `HOMEBREW_CASK_OPTS=--appdir` is silently ignored:

> Coder Desktop must be installed in /Applications because it contains a System Network Extension, which macOS only activates when the containing app lives in /Applications. As this cask uses a `pkg` installer, HOMEBREW_CASK_OPTS=--appdir has no effect.

## Why

A user with a global `HOMEBREW_CASK_OPTS=--appdir=~/Applications` reported (#255) that this cask quietly ignored it. There are two reasons it's ignored:

1. `--appdir` is only consulted by Homebrew's `app` stanza. This cask uses `pkg`, which hands the installer to `/usr/sbin/installer`; install destinations are baked into the pkg payload.
2. Even if we shipped an `app`-style cask, macOS refuses to activate a System Network Extension unless the containing app lives in `/Applications` — so `~/Applications` would break Coder Connect entirely.

Caveats are printed before `install_artifacts` runs (and re-emitted in the post-install summary), so users see the explanation even if the install ultimately fails on a locked-down `/Applications`.

## Validation

- Materialised the cask from the heredoc with a placeholder version/hash.
- Ran `brew style` against it on `Homebrew/brew` main: `1 file inspected, no offenses detected`.