### PR TITLE
fix: plumb literal headers through Helper HTTP requests

### DIFF
--- a/Coder-Desktop/Coder-DesktopHelper/Manager.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/Manager.swift
@@ -41,7 +41,7 @@ actor Manager {
                 "Failed to create directories for binary destination (\(dest)): \(error.localizedDescription)"
             )
         }
-        let client = Client(url: cfg.serverUrl)
+        let client = Client(url: cfg.serverUrl, headers: cfg.literalHeaders)
         let buildInfo: BuildInfoResponse
         do {
             buildInfo = try await client.buildInfo()
@@ -67,7 +67,8 @@ actor Manager {
             try await download(
                 src: binaryPath,
                 dest: dest,
-                urlSession: URLSession(configuration: sessionConfig)
+                urlSession: URLSession(configuration: sessionConfig),
+                headers: cfg.literalHeaders
             ) { progress in
                 pushProgress(stage: .downloading, downloadProgress: progress)
             }

--- a/Coder-Desktop/VPNLib/Download.swift
+++ b/Coder-Desktop/VPNLib/Download.swift
@@ -62,7 +62,7 @@ private final class DownloadManager: NSObject, @unchecked Sendable {
     ) async throws(DownloadError) {
         var req = URLRequest(url: src)
         for header in headers {
-            req.setValue(header.value, forHTTPHeaderField: header.name)
+            req.addValue(header.value, forHTTPHeaderField: header.name)
         }
         if FileManager.default.fileExists(atPath: dest.path) {
             if let existingFileData = try? Data(contentsOf: dest, options: .mappedIfSafe) {

--- a/Coder-Desktop/VPNLib/Download.swift
+++ b/Coder-Desktop/VPNLib/Download.swift
@@ -1,3 +1,4 @@
+import CoderSDK
 import CryptoKit
 import Foundation
 
@@ -5,12 +6,14 @@ public func download(
     src: URL,
     dest: URL,
     urlSession: URLSession,
+    headers: [HTTPHeader] = [],
     progressUpdates: (@Sendable (DownloadProgress) -> Void)? = nil
 ) async throws(DownloadError) {
     try await DownloadManager().download(
         src: src,
         dest: dest,
         urlSession: urlSession,
+        headers: headers,
         progressUpdates: progressUpdates.flatMap { throttle(interval: .milliseconds(10), $0) }
     )
 }
@@ -54,9 +57,13 @@ private final class DownloadManager: NSObject, @unchecked Sendable {
         src: URL,
         dest: URL,
         urlSession: URLSession,
+        headers: [HTTPHeader] = [],
         progressUpdates: (@Sendable (DownloadProgress) -> Void)?
     ) async throws(DownloadError) {
         var req = URLRequest(url: src)
+        for header in headers {
+            req.setValue(header.value, forHTTPHeaderField: header.name)
+        }
         if FileManager.default.fileExists(atPath: dest.path) {
             if let existingFileData = try? Data(contentsOf: dest, options: .mappedIfSafe) {
                 req.setValue(etag(data: existingFileData), forHTTPHeaderField: "If-None-Match")


### PR DESCRIPTION
## Summary

The Helper process (`Coder-DesktopHelper/Manager.swift`) makes two HTTP requests to the Coder server during `Manager.init` that were not attaching configured literal headers. Users behind reverse proxies like Cloudflare Access see the VPN fail immediately after `/api/v2/users/me` succeeds (which runs in the App process where headers are correctly plumbed).

## Changes

### `Manager.swift`
- Pass `cfg.literalHeaders` to the `Client` used for `buildInfo()` (line 44).
- Pass `cfg.literalHeaders` to `download()` for the binary fetch (lines 67-72).

### `VPNLib/Download.swift`
- Add `headers: [HTTPHeader]` parameter (defaulting to `[]`) to both the public `download()` function and the internal `DownloadManager.download()` method.
- Apply headers to the `URLRequest` before the `If-None-Match` ETag header.
- Add `import CoderSDK` for the `HTTPHeader` type.

## Why this fixes the reported issue

1. App calls `users/me` with headers -> succeeds (App process, `state.client` has headers)
2. VPN starts -> Helper's `Manager.init()` runs
3. Helper calls `buildInfo()` **without headers** -> blocked by Cloudflare Access (returns HTML)
4. Client fails to parse HTML as JSON -> VPN startup aborts

After this fix, both `buildInfo()` and the binary download include the literal headers configured in Desktop settings.

> [!NOTE]
> There is a remaining gap: SDWebImage icon fetches (`WorkspaceAppIcon.swift`) also don't include literal headers. This is cosmetic (broken icons, not broken VPN) and can be addressed separately.

<details>
<summary>Generated by Coder Agents (on behalf of @ethanndickson)</summary>
This PR was created by Coder's AI coding agents. Please review carefully.
</details>
