### PR TITLE
fix: send wake request to tunnel on system wake

### DIFF
--- a/Coder-Desktop/Coder-DesktopHelper/Manager.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/Manager.swift
@@ -155,7 +155,7 @@ actor Manager {
             Task { try? await appXPCServerDelegate.onPeerUpdate(update: msg.peerUpdate) }
         case let .log(logMsg):
             writeVpnLog(logMsg)
-        case .networkSettings, .start, .stop:
+        case .networkSettings, .start, .stop, .wake:
             logger.critical("received unexpected message: `\(String(describing: msgType))`")
         }
     }
@@ -182,7 +182,7 @@ actor Manager {
                     }
                 })
             }
-        case .log, .peerUpdate, .start, .stop:
+        case .log, .peerUpdate, .start, .stop, .wake:
             logger.critical("received unexpected rpc: `\(String(describing: msgType))`")
         }
     }
@@ -220,6 +220,12 @@ actor Manager {
             throw .errorResponse(msg: startResp.errorMessage)
         }
         logger.info("startVPN done")
+    }
+
+    // Notifies the tunnel that the system has woken from sleep. Best-effort:
+    // failures are logged by the speaker, not thrown.
+    func wake() async {
+        await speaker.wake()
     }
 
     func stopVPN() async throws(ManagerError) {

--- a/Coder-Desktop/Coder-DesktopHelper/Manager.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/Manager.swift
@@ -222,10 +222,14 @@ actor Manager {
         logger.info("startVPN done")
     }
 
-    // Notifies the tunnel that the system has woken from sleep. Best-effort:
-    // failures are logged by the speaker, not thrown.
+    // Notifies the tunnel that the system has woken from sleep.
     func wake() async {
-        await speaker.wake()
+        logger.info("sending wake rpc")
+        do {
+            try await speaker.wake()
+        } catch {
+            logger.error("wake rpc failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     func stopVPN() async throws(ManagerError) {

--- a/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
@@ -2,36 +2,35 @@ import Foundation
 import IOKit.pwr_mgt
 import os
 
-// IOKit message macros (iokit_common_msg) are not importable into Swift.
-// Values from <IOKit/IOMessage.h>.
+// From <IOKit/IOMessage.h>; the iokit_common_msg macros aren't imported into Swift.
 private let kIOMessageCanSystemSleep: UInt32 = 0xE000_0270
 private let kIOMessageSystemWillSleep: UInt32 = 0xE000_0280
 private let kIOMessageSystemHasPoweredOn: UInt32 = 0xE000_0300
 
-/// Observes system power events and invokes `onWake` once the system has
-/// fully woken from sleep.
-///
-/// `kIOMessageSystemHasPoweredOn` is only delivered on a full wake, never on
-/// a dark wake, matching the semantics of `NSWorkspace.didWakeNotification`
-/// while remaining deliverable to a daemon without a GUI session.
+/// Calls `onWake` when the system fully wakes from sleep (never on dark wake).
+/// Unlike `NSWorkspace.didWakeNotification`, IOKit power events are delivered
+/// to daemons running outside a GUI login session.
 final class SystemWakeObserver {
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "system-wake-observer")
-    private var notifyPort: IONotificationPortRef?
-    private var notifier: io_object_t = 0
     private var rootPort: io_connect_t = 0
     private let onWake: @Sendable () -> Void
 
-    init?(onWake: @escaping @Sendable () -> Void) {
+    init(onWake: @escaping @Sendable () -> Void) {
         self.onWake = onWake
-        let refcon = Unmanaged.passUnretained(self).toOpaque()
-        rootPort = IORegisterForSystemPower(refcon, &notifyPort, { refcon, _, messageType, messageArgument in
-            guard let refcon else { return }
-            let observer = Unmanaged<SystemWakeObserver>.fromOpaque(refcon).takeUnretainedValue()
-            observer.handle(messageType: messageType, messageArgument: messageArgument)
-        }, &notifier)
+        var notifyPort: IONotificationPortRef?
+        var notifier: io_object_t = 0
+        rootPort = IORegisterForSystemPower(
+            Unmanaged.passUnretained(self).toOpaque(),
+            &notifyPort,
+            { refcon, _, messageType, messageArgument in
+                let observer = Unmanaged<SystemWakeObserver>.fromOpaque(refcon!).takeUnretainedValue()
+                observer.handle(messageType: messageType, messageArgument: messageArgument)
+            },
+            &notifier
+        )
         guard rootPort != 0, let notifyPort else {
             logger.error("failed to register for system power notifications")
-            return nil
+            return
         }
         CFRunLoopAddSource(
             CFRunLoopGetMain(),
@@ -46,23 +45,10 @@ final class SystemWakeObserver {
             logger.info("system woke from sleep")
             onWake()
         case kIOMessageCanSystemSleep, kIOMessageSystemWillSleep:
-            // The system delays sleep until these are acknowledged.
+            // Sleep is delayed until acknowledged.
             IOAllowPowerChange(rootPort, Int(bitPattern: messageArgument))
         default:
             break
-        }
-    }
-
-    deinit {
-        if let notifyPort {
-            CFRunLoopRemoveSource(
-                CFRunLoopGetMain(),
-                IONotificationPortGetRunLoopSource(notifyPort).takeUnretainedValue(),
-                .defaultMode
-            )
-            IODeregisterForSystemPower(&notifier)
-            IOServiceClose(rootPort)
-            IONotificationPortDestroy(notifyPort)
         }
     }
 }

--- a/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
@@ -2,6 +2,12 @@ import Foundation
 import IOKit.pwr_mgt
 import os
 
+// IOKit message macros (iokit_common_msg) are not importable into Swift.
+// Values from <IOKit/IOMessage.h>.
+private let kIOMessageCanSystemSleep: UInt32 = 0xE000_0270
+private let kIOMessageSystemWillSleep: UInt32 = 0xE000_0280
+private let kIOMessageSystemHasPoweredOn: UInt32 = 0xE000_0300
+
 /// Observes system power events and invokes `onWake` once the system has
 /// fully woken from sleep.
 ///
@@ -36,10 +42,10 @@ final class SystemWakeObserver {
 
     private func handle(messageType: natural_t, messageArgument: UnsafeMutableRawPointer?) {
         switch messageType {
-        case UInt32(kIOMessageSystemHasPoweredOn):
+        case kIOMessageSystemHasPoweredOn:
             logger.info("system woke from sleep")
             onWake()
-        case UInt32(kIOMessageCanSystemSleep), UInt32(kIOMessageSystemWillSleep):
+        case kIOMessageCanSystemSleep, kIOMessageSystemWillSleep:
             // The system delays sleep until these are acknowledged.
             IOAllowPowerChange(rootPort, Int(bitPattern: messageArgument))
         default:

--- a/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
@@ -1,5 +1,5 @@
 import Foundation
-import IOKit
+import IOKit.pwr_mgt
 import os
 
 /// Observes system power events and invokes `onWake` once the system has

--- a/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
@@ -1,0 +1,63 @@
+import Foundation
+import IOKit
+import IOKit.pwr_mgt
+import os
+
+/// Observes system power events and invokes `onWake` once the system has
+/// fully woken from sleep.
+///
+/// `kIOMessageSystemHasPoweredOn` is only delivered on a full wake, never on
+/// a dark wake, matching the semantics of `NSWorkspace.didWakeNotification`
+/// while remaining deliverable to a daemon without a GUI session.
+final class SystemWakeObserver {
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "system-wake-observer")
+    private var notifyPort: IONotificationPortRef?
+    private var notifier: io_object_t = 0
+    private var rootPort: io_connect_t = 0
+    private let onWake: @Sendable () -> Void
+
+    init?(onWake: @escaping @Sendable () -> Void) {
+        self.onWake = onWake
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        rootPort = IORegisterForSystemPower(refcon, &notifyPort, { refcon, _, messageType, messageArgument in
+            guard let refcon else { return }
+            let observer = Unmanaged<SystemWakeObserver>.fromOpaque(refcon).takeUnretainedValue()
+            observer.handle(messageType: messageType, messageArgument: messageArgument)
+        }, &notifier)
+        guard rootPort != 0, let notifyPort else {
+            logger.error("failed to register for system power notifications")
+            return nil
+        }
+        CFRunLoopAddSource(
+            CFRunLoopGetMain(),
+            IONotificationPortGetRunLoopSource(notifyPort).takeUnretainedValue(),
+            .defaultMode
+        )
+    }
+
+    private func handle(messageType: natural_t, messageArgument: UnsafeMutableRawPointer?) {
+        switch messageType {
+        case UInt32(kIOMessageSystemHasPoweredOn):
+            logger.info("system woke from sleep")
+            onWake()
+        case UInt32(kIOMessageCanSystemSleep), UInt32(kIOMessageSystemWillSleep):
+            // The system delays sleep until these are acknowledged.
+            IOAllowPowerChange(rootPort, Int(bitPattern: messageArgument))
+        default:
+            break
+        }
+    }
+
+    deinit {
+        if let notifyPort {
+            CFRunLoopRemoveSource(
+                CFRunLoopGetMain(),
+                IONotificationPortGetRunLoopSource(notifyPort).takeUnretainedValue(),
+                .defaultMode
+            )
+            IODeregisterForSystemPower(&notifier)
+            IOServiceClose(rootPort)
+            IONotificationPortDestroy(notifyPort)
+        }
+    }
+}

--- a/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/SystemWakeObserver.swift
@@ -1,6 +1,5 @@
 import Foundation
 import IOKit
-import IOKit.pwr_mgt
 import os
 
 /// Observes system power events and invokes `onWake` once the system has

--- a/Coder-Desktop/Coder-DesktopHelper/main.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/main.swift
@@ -15,4 +15,13 @@ let appXPCServer = NSXPCListener(machServiceName: helperAppMachServiceName)
 appXPCServer.delegate = appXPCServerDelegate
 appXPCServer.resume()
 
+// Nudges the tunnel to rediscover network paths on system wake, as a short
+// same-network sleep often produces no link-change event the tunnel could
+// react to on its own.
+let wakeObserver = SystemWakeObserver {
+    Task { @MainActor in
+        await globalManager?.wake()
+    }
+}
+
 RunLoop.main.run()

--- a/Coder-Desktop/Coder-DesktopHelper/main.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/main.swift
@@ -15,9 +15,7 @@ let appXPCServer = NSXPCListener(machServiceName: helperAppMachServiceName)
 appXPCServer.delegate = appXPCServerDelegate
 appXPCServer.resume()
 
-// Nudges the tunnel to rediscover network paths on system wake, as a short
-// same-network sleep often produces no link-change event the tunnel could
-// react to on its own.
+// Nudge the tunnel to rediscover network paths on system wake.
 let wakeObserver = SystemWakeObserver {
     Task { @MainActor in
         await globalManager?.wake()

--- a/Coder-Desktop/VPNLib/Speaker+Wake.swift
+++ b/Coder-Desktop/VPNLib/Speaker+Wake.swift
@@ -1,32 +1,13 @@
-import Foundation
-import os
+import SwiftProtobuf
 
 public extension Speaker where SendMsg == Vpn_ManagerMessage, RecvMsg == Vpn_TunnelMessage {
-    /// Notifies the tunnel that the system has woken from sleep, so it can
-    /// immediately rediscover network paths instead of waiting for a periodic
-    /// re-STUN. No-op when the negotiated protocol version predates
-    /// WakeRequest (1.3). Best-effort: failures are logged, not thrown.
-    func wake() async {
-        let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "proto")
-        guard let negotiatedVersion, negotiatedVersion >= ProtoVersion(1, 3) else {
-            logger.debug("skipping wake rpc: negotiated protocol version doesn't support it")
-            return
-        }
-        logger.info("sending wake rpc")
-        let resp: Vpn_TunnelMessage
-        do {
-            resp = try await unaryRPC(
-                .with { msg in
-                    msg.wake = .init()
-                })
-        } catch {
-            logger.error("wake rpc failed: \(error.localizedDescription, privacy: .public)")
-            return
-        }
-        guard case let .wake(wakeResp) = resp.msg else {
-            logger.error("unexpected wake rpc response: \(String(describing: resp.msg), privacy: .public)")
-            return
-        }
-        logger.debug("wake rpc response success: \(wakeResp.success)")
+    /// Asks the tunnel to rediscover network paths after system wake.
+    /// No-op if the negotiated protocol version predates WakeRequest (1.3).
+    func wake() async throws {
+        guard let negotiatedVersion, negotiatedVersion >= ProtoVersion(1, 3) else { return }
+        _ = try await unaryRPC(
+            .with { msg in
+                msg.wake = .init()
+            })
     }
 }

--- a/Coder-Desktop/VPNLib/Speaker+Wake.swift
+++ b/Coder-Desktop/VPNLib/Speaker+Wake.swift
@@ -2,12 +2,33 @@ import SwiftProtobuf
 
 public extension Speaker where SendMsg == Vpn_ManagerMessage, RecvMsg == Vpn_TunnelMessage {
     /// Asks the tunnel to rediscover network paths after system wake.
-    /// No-op if the negotiated protocol version predates WakeRequest (1.3).
-    func wake() async throws {
-        guard let negotiatedVersion, negotiatedVersion >= ProtoVersion(1, 3) else { return }
-        _ = try await unaryRPC(
-            .with { msg in
-                msg.wake = .init()
-            })
+    func wake() async throws(WakeError) {
+        guard let negotiatedVersion, negotiatedVersion >= ProtoVersion(1, 3) else {
+            throw .unsupportedVersion(negotiatedVersion)
+        }
+        do {
+            _ = try await unaryRPC(
+                .with { msg in
+                    msg.wake = .init()
+                })
+        } catch {
+            throw .failedRPC(error)
+        }
     }
+}
+
+public enum WakeError: Error {
+    case unsupportedVersion(ProtoVersion?)
+    case failedRPC(any Error)
+
+    public var description: String {
+        switch self {
+        case let .unsupportedVersion(version):
+            "wake requires tunnel protocol version 1.3, negotiated: \(version?.description ?? "none")"
+        case let .failedRPC(err):
+            "failed rpc: \(err.localizedDescription)"
+        }
+    }
+
+    public var localizedDescription: String { description }
 }

--- a/Coder-Desktop/VPNLib/Speaker+Wake.swift
+++ b/Coder-Desktop/VPNLib/Speaker+Wake.swift
@@ -1,0 +1,32 @@
+import Foundation
+import os
+
+public extension Speaker where SendMsg == Vpn_ManagerMessage, RecvMsg == Vpn_TunnelMessage {
+    /// Notifies the tunnel that the system has woken from sleep, so it can
+    /// immediately rediscover network paths instead of waiting for a periodic
+    /// re-STUN. No-op when the negotiated protocol version predates
+    /// WakeRequest (1.3). Best-effort: failures are logged, not thrown.
+    func wake() async {
+        let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "proto")
+        guard let negotiatedVersion, negotiatedVersion >= ProtoVersion(1, 3) else {
+            logger.debug("skipping wake rpc: negotiated protocol version doesn't support it")
+            return
+        }
+        logger.info("sending wake rpc")
+        let resp: Vpn_TunnelMessage
+        do {
+            resp = try await unaryRPC(
+                .with { msg in
+                    msg.wake = .init()
+                })
+        } catch {
+            logger.error("wake rpc failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        guard case let .wake(wakeResp) = resp.msg else {
+            logger.error("unexpected wake rpc response: \(String(describing: resp.msg), privacy: .public)")
+            return
+        }
+        logger.debug("wake rpc response success: \(wakeResp.success)")
+    }
+}

--- a/Coder-Desktop/VPNLib/Speaker.swift
+++ b/Coder-Desktop/VPNLib/Speaker.swift
@@ -64,8 +64,7 @@ public actor Speaker<SendMsg: RPCMessage & Message, RecvMsg: RPCMessage & Messag
     private let receiver: Receiver<RecvMsg>
     private let secretary = RPCSecretary<RecvMsg>()
     let role: ProtoRole
-    /// The protocol version negotiated during the handshake, or nil if the
-    /// handshake has not yet completed.
+    /// The version negotiated during the handshake, or nil before it completes.
     public private(set) var negotiatedVersion: ProtoVersion?
 
     /// Creates an instance that communicates over the provided file handles.
@@ -99,10 +98,8 @@ public actor Speaker<SendMsg: RPCMessage & Message, RecvMsg: RPCMessage & Messag
     public func handshake() async throws(HandshakeError) {
         let hndsh = Handshaker(writeFD: writeFD, dispatch: dispatch, queue: queue, role: role,
                                versions: [ProtoVersion(1, 3)])
-        // All versions on the same major version are backwards compatible, so
-        // we don't need to change any behavior based on the negotiated minor
-        // version, but we record it so callers can gate messages the peer
-        // doesn't understand, e.g. WakeRequest (1.3).
+        // Minor versions are backwards compatible, so the negotiated version
+        // is only recorded to gate messages newer than the peer.
         negotiatedVersion = try await hndsh.handshake()
     }
 

--- a/Coder-Desktop/VPNLib/Speaker.swift
+++ b/Coder-Desktop/VPNLib/Speaker.swift
@@ -22,15 +22,19 @@ enum ProtoRole: String {
 }
 
 /// A version of the VPN protocol that can be negotiated.
-public struct ProtoVersion: CustomStringConvertible, Equatable, Codable, Sendable {
+public struct ProtoVersion: CustomStringConvertible, Equatable, Comparable, Codable, Sendable {
     let major: Int
     let minor: Int
 
     public var description: String { "\(major).\(minor)" }
 
-    init(_ major: Int, _ minor: Int) {
+    public init(_ major: Int, _ minor: Int) {
         self.major = major
         self.minor = minor
+    }
+
+    public static func < (lhs: ProtoVersion, rhs: ProtoVersion) -> Bool {
+        (lhs.major, lhs.minor) < (rhs.major, rhs.minor)
     }
 
     init(parse str: String) throws(HandshakeError) {
@@ -60,6 +64,9 @@ public actor Speaker<SendMsg: RPCMessage & Message, RecvMsg: RPCMessage & Messag
     private let receiver: Receiver<RecvMsg>
     private let secretary = RPCSecretary<RecvMsg>()
     let role: ProtoRole
+    /// The protocol version negotiated during the handshake, or nil if the
+    /// handshake has not yet completed.
+    public private(set) var negotiatedVersion: ProtoVersion?
 
     /// Creates an instance that communicates over the provided file handles.
     public init(writeFD: FileHandle, readFD: FileHandle) {
@@ -91,11 +98,12 @@ public actor Speaker<SendMsg: RPCMessage & Message, RecvMsg: RPCMessage & Messag
     /// Does the VPN Protocol handshake and validates the result
     public func handshake() async throws(HandshakeError) {
         let hndsh = Handshaker(writeFD: writeFD, dispatch: dispatch, queue: queue, role: role,
-                               versions: [ProtoVersion(1, 1)])
-        // ignore the version for now because we know it can only be 1.0 or 1.1.
-        // 1.1 adds support for telemetry to StartRequest, but since setting these
-        // fields won't adversely affect a 1.0 speaker, we set them regardless.
-        try _ = await hndsh.handshake()
+                               versions: [ProtoVersion(1, 3)])
+        // All versions on the same major version are backwards compatible, so
+        // we don't need to change any behavior based on the negotiated minor
+        // version, but we record it so callers can gate messages the peer
+        // doesn't understand, e.g. WakeRequest (1.3).
+        negotiatedVersion = try await hndsh.handshake()
     }
 
     /// Send a unary RPC message and handle the response

--- a/Coder-Desktop/VPNLib/vpn.pb.swift
+++ b/Coder-Desktop/VPNLib/vpn.pb.swift
@@ -87,6 +87,14 @@ public struct Vpn_ManagerMessage: Sendable {
     set {msg = .stop(newValue)}
   }
 
+  public var wake: Vpn_WakeRequest {
+    get {
+      if case .wake(let v)? = msg {return v}
+      return Vpn_WakeRequest()
+    }
+    set {msg = .wake(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Msg: Equatable, Sendable {
@@ -94,6 +102,7 @@ public struct Vpn_ManagerMessage: Sendable {
     case networkSettings(Vpn_NetworkSettingsResponse)
     case start(Vpn_StartRequest)
     case stop(Vpn_StopRequest)
+    case wake(Vpn_WakeRequest)
 
   }
 
@@ -159,6 +168,14 @@ public struct Vpn_TunnelMessage: Sendable {
     set {msg = .stop(newValue)}
   }
 
+  public var wake: Vpn_WakeResponse {
+    get {
+      if case .wake(let v)? = msg {return v}
+      return Vpn_WakeResponse()
+    }
+    set {msg = .wake(newValue)}
+  }
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_Msg: Equatable, Sendable {
@@ -167,6 +184,7 @@ public struct Vpn_TunnelMessage: Sendable {
     case networkSettings(Vpn_NetworkSettingsRequest)
     case start(Vpn_StartResponse)
     case stop(Vpn_StopResponse)
+    case wake(Vpn_WakeResponse)
 
   }
 
@@ -922,6 +940,30 @@ public struct Vpn_Status: Sendable {
   fileprivate var _peerUpdate: Vpn_PeerUpdate? = nil
 }
 
+/// WakeRequest is sent by the manager after the system wakes from sleep. The
+/// tunnel uses this as a hint to rediscover network paths.
+public struct Vpn_WakeRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Vpn_WakeResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var success: Bool = false
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "vpn"
@@ -972,6 +1014,7 @@ extension Vpn_ManagerMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     3: .standard(proto: "network_settings"),
     4: .same(proto: "start"),
     5: .same(proto: "stop"),
+    6: .same(proto: "wake"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1033,6 +1076,19 @@ extension Vpn_ManagerMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
           self.msg = .stop(v)
         }
       }()
+      case 6: try {
+        var v: Vpn_WakeRequest?
+        var hadOneofValue = false
+        if let current = self.msg {
+          hadOneofValue = true
+          if case .wake(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.msg = .wake(v)
+        }
+      }()
       default: break
       }
     }
@@ -1063,6 +1119,10 @@ extension Vpn_ManagerMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
       guard case .stop(let v)? = self.msg else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
     }()
+    case .wake?: try {
+      guard case .wake(let v)? = self.msg else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
     case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -1085,6 +1145,7 @@ extension Vpn_TunnelMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     4: .standard(proto: "network_settings"),
     5: .same(proto: "start"),
     6: .same(proto: "stop"),
+    7: .same(proto: "wake"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1159,6 +1220,19 @@ extension Vpn_TunnelMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
           self.msg = .stop(v)
         }
       }()
+      case 7: try {
+        var v: Vpn_WakeResponse?
+        var hadOneofValue = false
+        if let current = self.msg {
+          hadOneofValue = true
+          if case .wake(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.msg = .wake(v)
+        }
+      }()
       default: break
       }
     }
@@ -1192,6 +1266,10 @@ extension Vpn_TunnelMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     case .stop?: try {
       guard case .stop(let v)? = self.msg else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
+    case .wake?: try {
+      guard case .wake(let v)? = self.msg else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
     }()
     case nil: break
     }
@@ -2428,4 +2506,55 @@ extension Vpn_Status.Lifecycle: SwiftProtobuf._ProtoNameProviding {
     3: .same(proto: "STOPPING"),
     4: .same(proto: "STOPPED"),
   ]
+}
+
+extension Vpn_WakeRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".WakeRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Vpn_WakeRequest, rhs: Vpn_WakeRequest) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Vpn_WakeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".WakeResponse"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "success"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.success) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.success != false {
+      try visitor.visitSingularBoolField(value: self.success, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Vpn_WakeResponse, rhs: Vpn_WakeResponse) -> Bool {
+    if lhs.success != rhs.success {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }

--- a/Coder-Desktop/VPNLib/vpn.pb.swift
+++ b/Coder-Desktop/VPNLib/vpn.pb.swift
@@ -957,8 +957,6 @@ public struct Vpn_WakeResponse: Sendable {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var success: Bool = false
-
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -2529,31 +2527,18 @@ extension Vpn_WakeRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
 
 extension Vpn_WakeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WakeResponse"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "success"),
-  ]
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularBoolField(value: &self.success) }()
-      default: break
-      }
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.success != false {
-      try visitor.visitSingularBoolField(value: self.success, fieldNumber: 1)
-    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Vpn_WakeResponse, rhs: Vpn_WakeResponse) -> Bool {
-    if lhs.success != rhs.success {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Coder-Desktop/VPNLib/vpn.proto
+++ b/Coder-Desktop/VPNLib/vpn.proto
@@ -274,6 +274,4 @@ message Status {
 // tunnel uses this as a hint to rediscover network paths.
 message WakeRequest {}
 
-message WakeResponse {
-    bool success = 1;
-}
+message WakeResponse {}

--- a/Coder-Desktop/VPNLib/vpn.proto
+++ b/Coder-Desktop/VPNLib/vpn.proto
@@ -30,6 +30,7 @@ message ManagerMessage {
         NetworkSettingsResponse network_settings = 3;
         StartRequest start = 4;
         StopRequest stop = 5;
+        WakeRequest wake = 6;
     }
 }
 
@@ -42,6 +43,7 @@ message TunnelMessage {
         NetworkSettingsRequest network_settings = 4;
         StartResponse start = 5;
         StopResponse stop = 6;
+        WakeResponse wake = 7;
     }
 }
 
@@ -266,4 +268,12 @@ message Status {
     // should replace their current peer state. Only the Upserted fields will
     // be populated.
     PeerUpdate peer_update = 3;
+}
+
+// WakeRequest is sent by the manager after the system wakes from sleep. The
+// tunnel uses this as a hint to rediscover network paths.
+message WakeRequest {}
+
+message WakeResponse {
+    bool success = 1;
 }

--- a/Coder-Desktop/VPNLibTests/ProtoTests.swift
+++ b/Coder-Desktop/VPNLibTests/ProtoTests.swift
@@ -56,6 +56,16 @@ struct SenderReceiverTests {
 }
 
 @Suite(.timeLimit(.minutes(1)))
+struct ProtoVersionTests {
+    @Test func comparable() {
+        #expect(ProtoVersion(1, 1) < ProtoVersion(1, 3))
+        #expect(ProtoVersion(1, 3) >= ProtoVersion(1, 3))
+        #expect(ProtoVersion(2, 0) > ProtoVersion(1, 9))
+        #expect(!(ProtoVersion(1, 2) >= ProtoVersion(1, 3)))
+    }
+}
+
+@Suite(.timeLimit(.minutes(1)))
 struct HandshakerTests {
     let pipeMT = Pipe()
     let pipeTM = Pipe()

--- a/Coder-Desktop/VPNLibTests/SpeakerTests.swift
+++ b/Coder-Desktop/VPNLibTests/SpeakerTests.swift
@@ -37,7 +37,9 @@ struct SpeakerTests: Sendable {
     @Test func handshake() async throws {
         async let v = handshaker.handshake()
         try await uut.handshake()
+        // The peer only supports 1.1, so that's what we negotiate down to.
         #expect(try await v == ProtoVersion(1, 1))
+        #expect(await uut.negotiatedVersion == ProtoVersion(1, 1))
     }
 
     @Test func handleSingleMessage() async throws {
@@ -116,5 +118,95 @@ struct SpeakerTests: Sendable {
         _ = await managerDone
         try await sender.close()
         try await readDone.value
+    }
+}
+
+@Suite(.timeLimit(.minutes(1)))
+struct ManagerSpeakerTests: Sendable {
+    let pipeMT = Pipe()
+    let pipeTM = Pipe()
+    let queue: DispatchQueue = .global(qos: .utility)
+    let uut: Speaker<Vpn_ManagerMessage, Vpn_TunnelMessage>
+    let sender: Sender<Vpn_TunnelMessage>
+    let dispatch: DispatchIO
+    let receiver: Receiver<Vpn_ManagerMessage>
+    let handshaker: Handshaker
+
+    init() {
+        uut = Speaker(
+            writeFD: pipeMT.fileHandleForWriting,
+            readFD: pipeTM.fileHandleForReading
+        )
+        dispatch = DispatchIO(
+            type: .stream,
+            fileDescriptor: pipeMT.fileHandleForReading.fileDescriptor,
+            queue: queue,
+            cleanupHandler: { error in print("cleanupHandler: \(error)") }
+        )
+        sender = Sender(writeFD: pipeTM.fileHandleForWriting)
+        receiver = Receiver(dispatch: dispatch, queue: queue)
+        handshaker = Handshaker(
+            writeFD: pipeTM.fileHandleForWriting,
+            dispatch: dispatch, queue: queue,
+            role: .tunnel,
+            versions: [ProtoVersion(1, 3)]
+        )
+    }
+
+    @Test func handshake() async throws {
+        async let v = handshaker.handshake()
+        try await uut.handshake()
+        #expect(try await v == ProtoVersion(1, 3))
+        #expect(await uut.negotiatedVersion == ProtoVersion(1, 3))
+    }
+
+    @Test func wake() async throws {
+        async let v = handshaker.handshake()
+        try await uut.handshake()
+        _ = try await v
+        // Speaker must be reading from the receiver for `unaryRPC` to return
+        let readDone = Task {
+            for try await _ in uut {}
+        }
+        async let tunnelDone = Task {
+            var count = 0
+            for try await req in try await receiver.messages() {
+                #expect(req.msg == .wake(Vpn_WakeRequest()))
+                try #require(req.rpc.msgID != 0)
+                var reply = Vpn_TunnelMessage()
+                reply.wake = Vpn_WakeResponse()
+                reply.wake.success = true
+                reply.rpc.responseTo = req.rpc.msgID
+                try await sender.send(reply)
+                count += 1
+            }
+            #expect(count == 1)
+        }
+        await uut.wake()
+        await uut.closeWrite()
+        _ = await tunnelDone
+        try await sender.close()
+        try await readDone.value
+    }
+
+    @Test func wakeUnsupportedByPeer() async throws {
+        // A peer that predates WakeRequest (1.3) must not be sent one.
+        let oldHandshaker = Handshaker(
+            writeFD: pipeTM.fileHandleForWriting,
+            dispatch: dispatch, queue: queue,
+            role: .tunnel,
+            versions: [ProtoVersion(1, 1)]
+        )
+        async let v = oldHandshaker.handshake()
+        try await uut.handshake()
+        #expect(try await v == ProtoVersion(1, 1))
+        await uut.wake()
+        await uut.closeWrite()
+        var count = 0
+        for try await _ in try await receiver.messages() {
+            count += 1
+        }
+        #expect(count == 0)
+        try await sender.close()
     }
 }

--- a/Coder-Desktop/VPNLibTests/SpeakerTests.swift
+++ b/Coder-Desktop/VPNLibTests/SpeakerTests.swift
@@ -187,7 +187,9 @@ struct ManagerSpeakerTests: Sendable {
         async let v = oldHandshaker.handshake()
         try await uut.handshake()
         #expect(try await v == ProtoVersion(1, 1))
-        try await uut.wake()
+        await #expect(throws: WakeError.self) {
+            try await uut.wake()
+        }
         await uut.closeWrite()
         var count = 0
         for try await _ in try await receiver.messages() {

--- a/Coder-Desktop/VPNLibTests/SpeakerTests.swift
+++ b/Coder-Desktop/VPNLibTests/SpeakerTests.swift
@@ -37,7 +37,6 @@ struct SpeakerTests: Sendable {
     @Test func handshake() async throws {
         async let v = handshaker.handshake()
         try await uut.handshake()
-        // The peer only supports 1.1, so that's what we negotiate down to.
         #expect(try await v == ProtoVersion(1, 1))
         #expect(await uut.negotiatedVersion == ProtoVersion(1, 1))
     }
@@ -153,36 +152,25 @@ struct ManagerSpeakerTests: Sendable {
         )
     }
 
-    @Test func handshake() async throws {
+    @Test func wake() async throws {
         async let v = handshaker.handshake()
         try await uut.handshake()
         #expect(try await v == ProtoVersion(1, 3))
         #expect(await uut.negotiatedVersion == ProtoVersion(1, 3))
-    }
-
-    @Test func wake() async throws {
-        async let v = handshaker.handshake()
-        try await uut.handshake()
-        _ = try await v
         // Speaker must be reading from the receiver for `unaryRPC` to return
         let readDone = Task {
             for try await _ in uut {}
         }
         async let tunnelDone = Task {
-            var count = 0
             for try await req in try await receiver.messages() {
                 #expect(req.msg == .wake(Vpn_WakeRequest()))
-                try #require(req.rpc.msgID != 0)
                 var reply = Vpn_TunnelMessage()
                 reply.wake = Vpn_WakeResponse()
-                reply.wake.success = true
                 reply.rpc.responseTo = req.rpc.msgID
                 try await sender.send(reply)
-                count += 1
             }
-            #expect(count == 1)
         }
-        await uut.wake()
+        try await uut.wake()
         await uut.closeWrite()
         _ = await tunnelDone
         try await sender.close()
@@ -190,7 +178,6 @@ struct ManagerSpeakerTests: Sendable {
     }
 
     @Test func wakeUnsupportedByPeer() async throws {
-        // A peer that predates WakeRequest (1.3) must not be sent one.
         let oldHandshaker = Handshaker(
             writeFD: pipeTM.fileHandleForWriting,
             dispatch: dispatch, queue: queue,
@@ -200,7 +187,7 @@ struct ManagerSpeakerTests: Sendable {
         async let v = oldHandshaker.handshake()
         try await uut.handshake()
         #expect(try await v == ProtoVersion(1, 1))
-        await uut.wake()
+        try await uut.wake()
         await uut.closeWrite()
         var count = 0
         for try await _ in try await receiver.messages() {


### PR DESCRIPTION
After macOS sleep/wake, Coder Connect can stay unusable for minutes when no link-change event fires, leaving path re-discovery to the periodic re-STUN timer (coder/coder#26736).

The daemon-side hook merged in coder/coder#26739 (`WakeRequest`/`WakeResponse`, tunnel protocol `1.3`). This PR makes Coder Desktop emit it:

* The helper daemon registers for IOKit power events via `IORegisterForSystemPower` and reacts only to `kIOMessageSystemHasPoweredOn`, which is delivered on full wake only, never on dark wake.
* `Speaker` now advertises protocol `1.3` and records the negotiated version.
* On wake, the manager sends `WakeRequest` over the existing tunnel RPC channel, gated on negotiated version `>= 1.3` so older daemons are never sent a message they don't understand. Failures are logged; nothing is torn down.
* `vpn.proto` synced with the wake messages and `vpn.pb.swift` regenerated with protoc-gen-swift 1.28.2 (matching the pinned SwiftProtobuf version).

### Why IOKit instead of `NSWorkspace.didWakeNotification`?

The helper is a root LaunchDaemon with no GUI login session, and `NSWorkspace` notifications are only delivered to processes inside one (apps/LaunchAgents). IOKit power notifications are delivered to daemons, and `kIOMessageSystemHasPoweredOn` has the same full-wake-only semantics as `didWakeNotification` ([https://developer.apple.com/forums/thread/770517](<https://developer.apple.com/forums/thread/770517>)). Since the helper owns the tunnel lifecycle, the wake kick works even when the menu-bar app isn't running.

## Tests

* `ProtoVersion` comparison (`Comparable`).
* Handshake exposes the negotiated version.
* `Speaker.wake()` round-trip over an in-memory pipe.
* `Speaker.wake()` is a no-op against a 1.1 peer.

<details><summary>Decision log</summary>

* **Version gating**: `Speaker.handshake()` previously discarded the negotiated version; it now stores it. The wake RPC lives in a `Speaker` extension typed to the manager role so the gate is unit-testable; logging happens in `Manager.wake()` like the other RPCs.
* `WakeResponse.success`: kept in the proto for wire parity with upstream, but not read by the client.
* **Proto sync**: applied only the wake additions instead of a full upstream file sync; upstream reformatted to tabs and added Windows-only `StartProgress` messages, both of which would add noise. Generated bindings are additive only.
* **Debounce**: none client-side; the daemon already debounces wake-triggered rebinds (5s) per coder/coder#26739.

</details>

Closes coder/coder-desktop-macos#260

---

Generated by Coder Agents on behalf of @EhabY.