### PR TITLE
feat: send coder User-Agent on all deployment requests

### DIFF
--- a/Coder-Desktop/Coder-DesktopHelper/Manager.swift
+++ b/Coder-Desktop/Coder-DesktopHelper/Manager.swift
@@ -41,7 +41,7 @@ actor Manager {
                 "Failed to create directories for binary destination (\(dest)): \(error.localizedDescription)"
             )
         }
-        let client = Client(url: cfg.serverUrl, headers: cfg.literalHeaders)
+        let client = Client(url: cfg.serverUrl, headers: cfg.literalHeaders, component: .helper)
         let buildInfo: BuildInfoResponse
         do {
             buildInfo = try await client.buildInfo()
@@ -68,7 +68,8 @@ actor Manager {
                 src: binaryPath,
                 dest: dest,
                 urlSession: URLSession(configuration: sessionConfig),
-                headers: cfg.literalHeaders
+                headers: cfg.literalHeaders,
+                component: .helper
             ) { progress in
                 pushProgress(stage: .downloading, downloadProgress: progress)
             }

--- a/Coder-Desktop/CoderSDK/Client.swift
+++ b/Coder-Desktop/CoderSDK/Client.swift
@@ -4,11 +4,18 @@ public struct Client: Sendable {
     public let url: URL
     public var token: String?
     public var headers: [HTTPHeader]
+    public var component: CoderComponent
 
-    public init(url: URL, token: String? = nil, headers: [HTTPHeader] = []) {
+    public init(
+        url: URL,
+        token: String? = nil,
+        headers: [HTTPHeader] = [],
+        component: CoderComponent = .app
+    ) {
         self.url = url
         self.token = token
         self.headers = headers
+        self.component = component
     }
 
     func request(
@@ -25,6 +32,7 @@ public struct Client: Sendable {
             path: path,
             method: method,
             headers: headers,
+            component: component,
             body: body
         )
     }
@@ -41,7 +49,8 @@ public struct Client: Sendable {
             baseURL: url,
             path: path,
             method: method,
-            headers: headers
+            headers: headers,
+            component: component
         )
     }
 }
@@ -115,11 +124,13 @@ func doRequest(
     path: String,
     method: HTTPMethod,
     headers: [HTTPHeader] = [],
+    component: CoderComponent = .app,
     body: Data? = nil
 ) async throws(SDKError) -> HTTPResponse {
     let url = baseURL.appendingPathComponent(path)
     var req = URLRequest(url: url)
     req.httpMethod = method.rawValue
+    req.setCoderUserAgent(component, unlessIn: headers)
     for header in headers {
         req.addValue(header.value, forHTTPHeaderField: header.name)
     }
@@ -142,6 +153,7 @@ func request(
     path: String,
     method: HTTPMethod,
     headers: [HTTPHeader] = [],
+    component: CoderComponent = .app,
     body: some Encodable & Sendable
 ) async throws(SDKError) -> HTTPResponse {
     let encodedBody: Data
@@ -155,6 +167,7 @@ func request(
         path: path,
         method: method,
         headers: headers,
+        component: component,
         body: encodedBody
     )
 }
@@ -163,13 +176,15 @@ func request(
     baseURL: URL,
     path: String,
     method: HTTPMethod,
-    headers: [HTTPHeader] = []
+    headers: [HTTPHeader] = [],
+    component: CoderComponent = .app
 ) async throws(SDKError) -> HTTPResponse {
     try await doRequest(
         baseURL: baseURL,
         path: path,
         method: method,
-        headers: headers
+        headers: headers,
+        component: component
     )
 }
 

--- a/Coder-Desktop/CoderSDK/HTTP.swift
+++ b/Coder-Desktop/CoderSDK/HTTP.swift
@@ -25,4 +25,5 @@ enum HTTPMethod: String, Equatable, Hashable, Sendable {
 
 enum Headers {
     static let sessionToken = "Coder-Session-Token"
+    static let userAgent = "User-Agent"
 }

--- a/Coder-Desktop/CoderSDK/UserAgent.swift
+++ b/Coder-Desktop/CoderSDK/UserAgent.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Identifies which Coder Desktop process is making a request.
+public enum CoderComponent: String, Sendable {
+    case app = "coder-desktop"
+    case helper = "coder-desktop-core"
+}
+
+/// Go's `GOARCH` spelling, so a single pattern matches the CLI, the vpn-daemon and Desktop client.
+enum GoArch: String, Sendable {
+    case arm64
+    case amd64
+}
+
+enum UserAgentDefaults {
+    static let goos = "darwin"
+    static let unknownVersion = "0.0.0"
+
+    #if arch(arm64)
+        static let arch: GoArch = .arm64
+    #elseif arch(x86_64)
+        static let arch: GoArch = .amd64
+    #endif
+
+    static var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? unknownVersion
+    }
+}
+
+/// Formats a `User-Agent` as `<token>/<version> (<goos>/<goarch>)`.
+func userAgent(
+    component: CoderComponent,
+    version: String = UserAgentDefaults.version,
+    arch: GoArch = UserAgentDefaults.arch
+) -> String {
+    "\(component.rawValue)/\(version) (\(UserAgentDefaults.goos)/\(arch.rawValue))"
+}
+
+public extension URLRequest {
+    /// Sets the Coder `User-Agent`, unless `headers` already carries one.
+    mutating func setCoderUserAgent(_ component: CoderComponent, unlessIn headers: [HTTPHeader]) {
+        let callerSuppliedUA = headers.contains {
+            $0.name.caseInsensitiveCompare(Headers.userAgent) == .orderedSame
+        }
+        guard !callerSuppliedUA else { return }
+        setValue(userAgent(component: component), forHTTPHeaderField: Headers.userAgent)
+    }
+}

--- a/Coder-Desktop/CoderSDKTests/UserAgentTests.swift
+++ b/Coder-Desktop/CoderSDKTests/UserAgentTests.swift
@@ -1,0 +1,109 @@
+@testable import CoderSDK
+import Foundation
+import Mocker
+import Testing
+
+@Suite(.timeLimit(.minutes(1)))
+struct UserAgentTests {
+    // The pattern operators are expected to match against every Coder client.
+    static let grammar = #"^coder-desktop(-core)?/[0-9]+\.[0-9]+\.[0-9]+ \(darwin/(amd64|arm64)\)$"#
+
+    static let stubVersion = "0.8.4"
+    static let stubServerVersion = "v2.18.2"
+
+    @Test
+    func appToken() {
+        #expect(
+            userAgent(component: .app, version: Self.stubVersion, arch: .arm64)
+                == "coder-desktop/\(Self.stubVersion) (darwin/arm64)"
+        )
+    }
+
+    @Test
+    func helperToken() {
+        #expect(
+            userAgent(component: .helper, version: Self.stubVersion, arch: .arm64)
+                == "coder-desktop-core/\(Self.stubVersion) (darwin/arm64)"
+        )
+    }
+
+    // The CLI and the vpn-daemon report `amd64`, so an Intel build must too.
+    @Test
+    func intelReportsGoArchNotSwiftArch() {
+        let ua = userAgent(component: .app, version: Self.stubVersion, arch: .amd64)
+        #expect(ua == "coder-desktop/\(Self.stubVersion) (darwin/amd64)")
+        #expect(!ua.contains("x86_64"))
+    }
+
+    @Test
+    func matchesGrammar() throws {
+        let regex = try Regex(Self.grammar)
+        for component in [CoderComponent.app, .helper] {
+            for arch in [GoArch.arm64, .amd64] {
+                let ua = userAgent(component: component, version: Self.stubVersion, arch: arch)
+                #expect(ua.contains(regex))
+            }
+            // The version the running bundle actually reports.
+            #expect(userAgent(component: component).contains(regex))
+        }
+    }
+
+    @Test
+    func missingVersionFallsBackToValidGrammar() throws {
+        let regex = try Regex(Self.grammar)
+        let ua = userAgent(
+            component: .app,
+            version: UserAgentDefaults.unknownVersion,
+            arch: .arm64
+        )
+        #expect(ua == "coder-desktop/\(UserAgentDefaults.unknownVersion) (darwin/arm64)")
+        #expect(ua.contains(regex))
+    }
+
+    @Test
+    func setOnRequest() async throws {
+        // A distinct host per test: Mocker's registry is process-global and
+        // suites run in parallel.
+        let url = URL(string: "https://ua-default.example.com")!
+        let client = Client(url: url, component: .helper)
+        let sentUA = try await capturedUserAgent(client: client, url: url)
+
+        #expect(try sentUA.contains(Regex(Self.grammar)))
+        #expect(sentUA.hasPrefix("coder-desktop-core/"))
+    }
+
+    // A user-configured literal header must replace ours outright. Caller headers
+    // are applied with `addValue`, which would otherwise comma-join the two.
+    @Test
+    func callerSuppliedUserAgentWins() async throws {
+        let url = URL(string: "https://ua-override.example.com")!
+        let custom = "my-own-agent/1.2.3"
+        let client = Client(
+            url: url,
+            headers: [.init(name: "user-agent", value: custom)],
+            component: .helper
+        )
+        let sentUA = try await capturedUserAgent(client: client, url: url)
+
+        #expect(sentUA == custom)
+        #expect(!sentUA.contains("coder-desktop"))
+    }
+
+    /// Runs `buildInfo()` against a mock and returns the `User-Agent` it sent.
+    private func capturedUserAgent(client: Client, url: URL) async throws -> String {
+        var mock = try Mock(
+            url: url.appending(path: "api/v2/buildinfo"),
+            contentType: .json,
+            statusCode: 200,
+            data: [.get: CoderSDK.encoder.encode(BuildInfoResponse(version: Self.stubServerVersion))]
+        )
+        var sentUA: String?
+        mock.onRequestHandler = OnRequestHandler { req in
+            sentUA = req.value(forHTTPHeaderField: Headers.userAgent)
+        }
+        mock.register()
+
+        _ = try await client.buildInfo()
+        return try #require(sentUA)
+    }
+}

--- a/Coder-Desktop/VPNLib/Download.swift
+++ b/Coder-Desktop/VPNLib/Download.swift
@@ -7,6 +7,7 @@ public func download(
     dest: URL,
     urlSession: URLSession,
     headers: [HTTPHeader] = [],
+    component: CoderComponent = .app,
     progressUpdates: (@Sendable (DownloadProgress) -> Void)? = nil
 ) async throws(DownloadError) {
     try await DownloadManager().download(
@@ -14,6 +15,7 @@ public func download(
         dest: dest,
         urlSession: urlSession,
         headers: headers,
+        component: component,
         progressUpdates: progressUpdates.flatMap { throttle(interval: .milliseconds(10), $0) }
     )
 }
@@ -58,9 +60,11 @@ private final class DownloadManager: NSObject, @unchecked Sendable {
         dest: URL,
         urlSession: URLSession,
         headers: [HTTPHeader] = [],
+        component: CoderComponent = .app,
         progressUpdates: (@Sendable (DownloadProgress) -> Void)?
     ) async throws(DownloadError) {
         var req = URLRequest(url: src)
+        req.setCoderUserAgent(component, unlessIn: headers)
         for header in headers {
             req.addValue(header.value, forHTTPHeaderField: header.name)
         }


### PR DESCRIPTION
* [DEVEX-778](https://linear.app/codercom/issue/DEVEX-778/desktop-sends-no-user-agent-header-all-api-requests-blocked-by-aws-waf)

## Summary

This is a consistency change, not a bug fix. Injects a default `User-Agent` encoding the os and arch (`darwin`) 

The problem is that the default carries no Coder identifier (`Coder Desktop/1 CFNetwork/<ver> Darwin/<ver>`), so operators can't write one WAF allowlist rule covering every Coder client, and deployment access logs can't tell Desktop traffic apart from any other CFNetwork app. This aligns macOS with the grammar the CLI, the vpn-daemon, and coder/coder-desktop-windows#180 and coder/coder-desktop-linux#7 all use so a single pattern matches all of them.


| Origin | Before | After |
|---|---|---|
| App | `Coder Desktop/1 CFNetwork/<ver> Darwin/<ver>` | `coder-desktop/0.8.4 (darwin/arm64)` |
| Helper | `Coder Desktop/1 CFNetwork/<ver> Darwin/<ver>` | `coder-desktop-core/0.8.4 (darwin/arm64)` |

## What changed

- **`CoderSDK/UserAgent.swift`** (new): formats `User-Agent` as
  `<token>/<version> (<goos>/<goarch>)`, e.g. `coder-desktop/0.8.4 (darwin/arm64)`.
  Platform names follow Go's `GOOS`/`GOARCH` rather than Swift's, so `#if arch(x86_64)`
  reports `amd64`, not `x86_64`. Version comes from
  `Bundle.main.infoDictionary?["CFBundleShortVersionString"]` — the same lookup used in
  `VPNLib/TelemetryEnricher.swift` — falling back to `0.0.0` so the string stays
  regex-valid.
- **`CoderSDK/HTTP.swift`**: adds `Headers.userAgent` beside the existing
  `Headers.sessionToken`.
- **SDK HTTP client**: `doRequest` — the single chokepoint both `Client` and
  `AgentClient` route through — sets the header, selected by a `CoderComponent` enum
  (`app` / `helper`). It is applied only when the caller supplied no `User-Agent`:
  caller headers are attached with `addValue`, which comma-joins repeated fields, so an
  unconditional set would have merged with a user's configured header rather than
  yielding to it. Same guarantee as .NET's `DefaultRequestHeaders` on the other two
  clients.
- **`VPNLib/Download.swift`**: same treatment on the tunnel binary download.
- **`Coder-DesktopHelper/Manager.swift`**: the `Client` and the binary download identify
  as `CoderComponent.helper`, covering the buildinfo call and the tunnel binary. The
  parameter defaults to `.app`, so no app-side call site changes.

## Validation

- **`CoderSDKTests`: 2 → 9 passing** (+7 `UserAgentTests`). Covers both tokens against
  `^coder-desktop(-core)?/[0-9]+\.[0-9]+\.[0-9]+ \(darwin/(amd64|arm64)\)$`, that an
  Intel build reports `amd64` and not `x86_64`, the `0.0.0` fallback, the header on the
  wire via the existing `Mocker` fixture, and that a caller-supplied `User-Agent`
  overrides the default rather than comma-joining with it.
- `make test`: passing, built and started locally (unsigned)
<img width="293" height="279" alt="Screenshot 2026-09-04 at 9 28 03 AM" src="https://github.com/user-attachments/assets/b816ac69-6eff-4ed1-8a63-b672b5f476b9" />

