### PR TITLE
feat: send push notifications on VPN failures

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -44,7 +44,7 @@ struct DesktopApp: App {
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "app-delegate")
-    private var menuBar: MenuBarController?
+    var menuBar: MenuBarController?
     let vpn: CoderVPNService
     let state: AppState
     let fileSyncDaemon: MutagenDaemon
@@ -81,6 +81,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         super.init()
         // `delegate` is weak
         UNUserNotificationCenter.current().delegate = self
+        vpn.onFailure = { [logger] tunnelError in
+            Task {
+                do {
+                    try await sendNotification(
+                        title: "Coder Connect has failed!",
+                        body: tunnelError.description,
+                        category: .vpnFailure
+                    )
+                } catch let notifError {
+                    logger.error("Failed to send notification (\(tunnelError.description)): \(notifError)")
+                }
+            }
+        }
     }
 
     func applicationDidFinishLaunching(_: Notification) {

--- a/Coder-Desktop/Coder-Desktop/Notifications.swift
+++ b/Coder-Desktop/Coder-Desktop/Notifications.swift
@@ -17,6 +17,24 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) async -> UNNotificationPresentationOptions {
         [.banner]
     }
+
+    nonisolated func userNotificationCenter(
+        _: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let category = response.notification.request.content.categoryIdentifier
+        let action = response.actionIdentifier
+        switch (category, action) {
+        case (NotificationCategory.vpnFailure.rawValue, UNNotificationDefaultActionIdentifier):
+            await showMenuBarWindow()
+        default:
+            break
+        }
+    }
+
+    private func showMenuBarWindow() {
+        menuBar?.menuBarExtra.toggleVisibility()
+    }
 }
 
 func sendNotification(title: String, body: String, category: NotificationCategory) async throws {
@@ -33,5 +51,6 @@ func sendNotification(title: String, body: String, category: NotificationCategor
 }
 
 enum NotificationCategory: String, CaseIterable {
+    case vpnFailure = "VPN_FAILURE"
     case uriFailure = "URI_FAILURE"
 }

--- a/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
@@ -61,6 +61,9 @@ final class CoderVPNService: NSObject, VPNService {
             if tunnelState == .connecting {
                 progress = .init(stage: .initial, downloadProgress: nil)
             }
+            if case let .failed(tunnelError) = tunnelState, tunnelState != oldValue {
+                onFailure?(tunnelError)
+            }
         }
     }
 
@@ -87,6 +90,7 @@ final class CoderVPNService: NSObject, VPNService {
     // Whether the VPN should start as soon as possible
     var startWhenReady: Bool = false
     var onStart: (() -> Void)?
+    var onFailure: ((VPNServiceError) -> Void)?
 
     // systemExtnDelegate holds a reference to the SystemExtensionDelegate so that it doesn't get
     // garbage collected while the OSSystemExtensionRequest is in flight, since the OS framework

--- a/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
@@ -61,7 +61,9 @@ final class CoderVPNService: NSObject, VPNService {
             if tunnelState == .connecting {
                 progress = .init(stage: .initial, downloadProgress: nil)
             }
-            if case let .failed(tunnelError) = tunnelState, tunnelState != oldValue {
+            if case let .failed(tunnelError) = tunnelState, tunnelState != oldValue,
+               tunnelError != .networkExtensionError(.unconfigured)
+            {
                 onFailure?(tunnelError)
             }
         }

--- a/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
+++ b/Coder-Desktop/Coder-Desktop/VPN/VPNService.swift
@@ -67,8 +67,22 @@ final class CoderVPNService: NSObject, VPNService {
         }
     }
 
-    @Published var sysExtnState: SystemExtensionState = .uninstalled
-    @Published var neState: NetworkExtensionState = .unconfigured
+    @Published var sysExtnState: SystemExtensionState = .uninstalled {
+        didSet {
+            if case .failed = sysExtnState, sysExtnState != oldValue {
+                onFailure?(.systemExtensionError(sysExtnState))
+            }
+        }
+    }
+
+    @Published var neState: NetworkExtensionState = .unconfigured {
+        didSet {
+            if case .failed = neState, neState != oldValue {
+                onFailure?(.networkExtensionError(neState))
+            }
+        }
+    }
+
     var state: VPNServiceState {
         guard sysExtnState == .installed else {
             return .failed(.systemExtensionError(sysExtnState))


### PR DESCRIPTION
Relates to #195. Supersedes #196.

When Coder Connect enters a failed state, the app now sends a push notification with the same error message that the menu shows. Clicking the notification opens the menu.

`CoderVPNService` exposes an `onFailure` callback next to the existing `onStart`. It fires on each transition of `tunnelState`, `neState`, or `sysExtnState` into their `.failed` case, so tunnel errors, network extension errors, and system extension errors all notify. Pending approval and unconfigured states are not failures and stay silent. `AppDelegate` wires the callback to `sendNotification`, so the service stays free of UI code.
