### PR TITLE
fix: send coder User-Agent on workspace app icon fetches

### DIFF
--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -90,7 +90,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         UserDefaults.standard.setValue(Theme.Animation.tooltipDelay, forKey: "NSInitialToolTipDelay")
         // Init SVG loader
         SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
-        // Workspace app icons are fetched by SDWebImage, not `Client`, so they need the same User-Agent.
         SDWebImageDownloader.shared.setValue(CoderSDK.userAgent(component: .app), forHTTPHeaderField: "User-Agent")
 
         menuBar = .init(menuBarExtra: FluidMenuBarExtra(

--- a/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
+++ b/Coder-Desktop/Coder-Desktop/Coder_DesktopApp.swift
@@ -1,3 +1,4 @@
+import CoderSDK
 import FluidMenuBarExtra
 import NetworkExtension
 import os
@@ -89,6 +90,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         UserDefaults.standard.setValue(Theme.Animation.tooltipDelay, forKey: "NSInitialToolTipDelay")
         // Init SVG loader
         SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
+        // Workspace app icons are fetched by SDWebImage, not `Client`, so they need the same User-Agent.
+        SDWebImageDownloader.shared.setValue(CoderSDK.userAgent(component: .app), forHTTPHeaderField: "User-Agent")
 
         menuBar = .init(menuBarExtra: FluidMenuBarExtra(
             title: "Coder Desktop",

--- a/Coder-Desktop/CoderSDK/UserAgent.swift
+++ b/Coder-Desktop/CoderSDK/UserAgent.swift
@@ -27,7 +27,7 @@ enum UserAgentDefaults {
     }
 }
 
-/// The `User-Agent` `component` sends on deployment requests, as `<token>/<version> (<goos>/<goarch>)`.
+/// Formats a `User-Agent` as `<token>/<version> (<goos>/<goarch>)`.
 public func userAgent(component: CoderComponent) -> String {
     userAgent(component: component, version: UserAgentDefaults.version, arch: UserAgentDefaults.arch)
 }

--- a/Coder-Desktop/CoderSDK/UserAgent.swift
+++ b/Coder-Desktop/CoderSDK/UserAgent.swift
@@ -27,12 +27,12 @@ enum UserAgentDefaults {
     }
 }
 
-/// Formats a `User-Agent` as `<token>/<version> (<goos>/<goarch>)`.
-func userAgent(
-    component: CoderComponent,
-    version: String = UserAgentDefaults.version,
-    arch: GoArch = UserAgentDefaults.arch
-) -> String {
+/// The `User-Agent` `component` sends on deployment requests, as `<token>/<version> (<goos>/<goarch>)`.
+public func userAgent(component: CoderComponent) -> String {
+    userAgent(component: component, version: UserAgentDefaults.version, arch: UserAgentDefaults.arch)
+}
+
+func userAgent(component: CoderComponent, version: String, arch: GoArch) -> String {
     "\(component.rawValue)/\(version) (\(UserAgentDefaults.goos)/\(arch.rawValue))"
 }
 


### PR DESCRIPTION
Follow up to #264.

Workspace app icons are fetched by `SDWebImage` rather than `Client`, so they never picked up the `coder-desktop/<version> (darwin/<arch>)` User-Agent. `SDWebImage` sets its own default (`Coder Desktop/<version> (Mac OS X ...)`) instead, and relative icon URLs resolve to the deployment host, so these requests can be blocked by the same WAF rule.

The fix is just to set the header once on `SDWebImageDownloader.shared` at launch, next to where we register the SVG coder. I've made the one-argument `userAgent(component:)` public so the app target can reach it, whilst keeping the `version:`/`arch:` test knobs internal.

Icon URLs can be third-party, but the User-Agent carries nothing sensitive, so unlike literal headers it's fine to send it everywhere.
